### PR TITLE
[fix] 릴리즈 모드에서 에디터 실행시 최종 빌드 버전의 실행 파일이 빌드되지 않는 문제 해결

### DIFF
--- a/Engine/src/Runtime/Engine/EngineImpl.h
+++ b/Engine/src/Runtime/Engine/EngineImpl.h
@@ -190,6 +190,7 @@ namespace Alice
 		bool InitializeAll(Engine& owner, HINSTANCE hInstance, int nCmdShow);
 		void InitializeMainThreadAndRegistry();
 		std::filesystem::path InitializeResolveExeDir();
+		void ApplyEditorModeFromExeName(const std::filesystem::path& exeDir);
 		bool InitializeConfigureResourceManagers(const std::filesystem::path& exeDir);
 		bool InitializeValidateGameDataIfNeeded();
 		void InitializeLoadPvdSettings(const std::filesystem::path& exeDir);

--- a/Engine/src/Runtime/Engine/EngineInitialize.cpp
+++ b/Engine/src/Runtime/Engine/EngineInitialize.cpp
@@ -155,6 +155,7 @@ namespace Alice
 		InitializeMainThreadAndRegistry();
 
 		const std::filesystem::path exeDir = InitializeResolveExeDir();
+		ApplyEditorModeFromExeName(exeDir);
 
 		if (!InitializeConfigureResourceManagers(exeDir)) return false;
 		if (!InitializeValidateGameDataIfNeeded()) return false;
@@ -197,6 +198,47 @@ namespace Alice
 		wchar_t pathBuf[MAX_PATH] = {};
 		GetModuleFileNameW(nullptr, pathBuf, MAX_PATH);
 		return std::filesystem::path(pathBuf).parent_path();
+	}
+
+	void Engine::Impl::ApplyEditorModeFromExeName(const std::filesystem::path& exeDir)
+	{
+		// 실행 파일 이름에 따라 에디터/게임 모드를 강제합니다.
+		// - Launch.exe / AliceRenderer.exe  : 에디터 모드
+		// - AlicePlayer.exe : 게임 모드
+		wchar_t exePathBuf[MAX_PATH] = {};
+		std::filesystem::path exePath = exeDir;
+		if (GetModuleFileNameW(nullptr, exePathBuf, MAX_PATH) > 0)
+			exePath = std::filesystem::path(exePathBuf);
+
+		const std::wstring exeName = exePath.filename().wstring();
+		auto IsExe = [&](const wchar_t* name)
+		{
+			return _wcsicmp(exeName.c_str(), name) == 0;
+		};
+
+		bool forced = false;
+		if (IsExe(L"Launch.exe") || IsExe(L"AliceRenderer.exe"))
+		{
+			if (!m_editorMode)
+			{
+				m_editorMode = true;
+				forced = true;
+			}
+		}
+		else if (IsExe(L"AlicePlayer.exe"))
+		{
+			if (m_editorMode)
+			{
+				m_editorMode = false;
+				forced = true;
+			}
+		}
+
+		if (forced)
+		{
+			m_scriptSystem.SetEditorMode(m_editorMode);
+			ALICE_LOG_INFO("Engine::Initialize: editorMode forced by exe name (%ls) -> %d", exeName.c_str(), m_editorMode ? 1 : 0);
+		}
 	}
 
 	bool Engine::Impl::InitializeConfigureResourceManagers(const std::filesystem::path& exeDir)


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #16 

## 📝 작업 내용
- [x] 릴리즈 모드의 에디터에서 최종 빌드 exe 실행 파일이 나오지 않던 문제 해결

## 🔬 테스트 방법 (없으면 삭제)
- 

## 📸 스크린샷 (선택)
## ✅ 체크리스트
- [x] 빌드가 에러 없이 정상적으로 되나요?
- [ ] 불필요한 로그나 주석을 제거했나요?
- [x] 코딩 컨벤션을 지켰나요?