### PR TITLE
#17 그림자수치조정 및 렌더링 톤매핑 수정

### DIFF
--- a/Assets/Scenes/Decal/DecalDemo.scene
+++ b/Assets/Scenes/Decal/DecalDemo.scene
@@ -23,20 +23,29 @@
                 "outlineWidth": 0.0,
                 "roughness": 0.6000000238418579,
                 "shadingMode": -1,
+                "shadowStrength": 1.0,
                 "toonPbrBlur": false,
                 "toonPbrCut1": 0.20000000298023224,
                 "toonPbrCut2": 0.5,
                 "toonPbrCut3": 0.949999988079071,
                 "toonPbrLevel1": 0.10000000149011612,
+                "toonPbrLevel1Alpha": 1.0,
                 "toonPbrLevel2": 0.4000000059604645,
+                "toonPbrLevel2Alpha": 1.0,
                 "toonPbrLevel3": 0.699999988079071,
+                "toonPbrLevel3Alpha": 1.0,
+                "toonPbrRampIntensity": 0.0,
                 "toonPbrStrength": 1.0,
                 "transparent": false
             },
             "Scripts": [
                 {
                     "enabled": true,
-                    "name": "SceneSwitchExample"
+                    "name": "SceneSwitchExample",
+                    "props": {
+                        "targetSceneA": "",
+                        "targetSceneB": ""
+                    }
                 }
             ],
             "SkinnedAnimation": {
@@ -95,13 +104,18 @@
                 "outlineWidth": 0.0,
                 "roughness": 0.800000011920929,
                 "shadingMode": -1,
+                "shadowStrength": 1.0,
                 "toonPbrBlur": false,
                 "toonPbrCut1": 0.20000000298023224,
                 "toonPbrCut2": 0.5,
                 "toonPbrCut3": 0.949999988079071,
                 "toonPbrLevel1": 0.10000000149011612,
+                "toonPbrLevel1Alpha": 1.0,
                 "toonPbrLevel2": 0.4000000059604645,
+                "toonPbrLevel2Alpha": 1.0,
                 "toonPbrLevel3": 0.699999988079071,
+                "toonPbrLevel3Alpha": 1.0,
+                "toonPbrRampIntensity": 0.0,
                 "toonPbrStrength": 1.0,
                 "transparent": false
             },
@@ -161,7 +175,14 @@
             "Scripts": [
                 {
                     "enabled": false,
-                    "name": "DecalDemoController"
+                    "name": "DecalDemoController",
+                    "props": {
+                        "m_opacityMin": 0.3499999940395355,
+                        "m_opacityPulseSpeed": 1.5,
+                        "m_pulseOpacity": true,
+                        "m_spinSpeed": 0.6000000238418579,
+                        "m_uvScrollSpeed": 0.10000000149011612
+                    }
                 }
             ],
             "Transform": {
@@ -242,13 +263,18 @@
                 "outlineWidth": 0.0,
                 "roughness": 0.5,
                 "shadingMode": -1,
+                "shadowStrength": 1.0,
                 "toonPbrBlur": false,
                 "toonPbrCut1": 0.20000000298023224,
                 "toonPbrCut2": 0.5,
                 "toonPbrCut3": 0.949999988079071,
                 "toonPbrLevel1": 0.10000000149011612,
+                "toonPbrLevel1Alpha": 1.0,
                 "toonPbrLevel2": 0.4000000059604645,
+                "toonPbrLevel2Alpha": 1.0,
                 "toonPbrLevel3": 0.699999988079071,
+                "toonPbrLevel3Alpha": 1.0,
+                "toonPbrRampIntensity": 0.0,
                 "toonPbrStrength": 1.0,
                 "transparent": false
             },
@@ -326,9 +352,9 @@
                     "y": 0.699999988079071,
                     "z": 0.699999988079071
                 },
-                "envDiffuseStrength": 0.5799999833106995,
-                "envSpecularStrength": 0.8700000047683716,
-                "metalness": 0.0,
+                "envDiffuseStrength": 0.0,
+                "envSpecularStrength": 1.0,
+                "metalness": 0.06199999898672104,
                 "normalStrength": 1.0,
                 "outlineColor": {
                     "x": 0.0,
@@ -336,23 +362,28 @@
                     "z": 0.0
                 },
                 "outlineWidth": 0.0,
-                "roughness": 0.5,
+                "roughness": 0.8709999918937683,
                 "shadingMode": 7,
+                "shadowStrength": 0.0,
                 "toonPbrBlur": true,
-                "toonPbrCut1": 0.11900000274181366,
-                "toonPbrCut2": 0.257999986410141,
-                "toonPbrCut3": 0.40700000524520874,
-                "toonPbrLevel1": 0.0,
-                "toonPbrLevel2": 0.6800000071525574,
-                "toonPbrLevel3": 0.9480000138282776,
-                "toonPbrStrength": 0.968999981880188,
+                "toonPbrCut1": 0.3919999897480011,
+                "toonPbrCut2": 0.3089999854564667,
+                "toonPbrCut3": 0.4480000138282776,
+                "toonPbrLevel1": 0.6650000214576721,
+                "toonPbrLevel1Alpha": 0.42800000309944153,
+                "toonPbrLevel2": 0.722000002861023,
+                "toonPbrLevel2Alpha": 0.8199999928474426,
+                "toonPbrLevel3": 0.3919999897480011,
+                "toonPbrLevel3Alpha": 0.890999972820282,
+                "toonPbrRampIntensity": 1.0,
+                "toonPbrStrength": 1.0,
                 "transparent": false
             },
             "SkinnedAnimation": {
-                "clipIndex": 5,
+                "clipIndex": 0,
                 "playing": true,
                 "speed": 1.0,
-                "timeSec": 422.83480867091566
+                "timeSec": 280.07936621428235
             },
             "SkinnedMesh": {
                 "boneCount": 345,
@@ -364,7 +395,7 @@
                 "position": {
                     "x": 2.1910400390625,
                     "y": 0.03142665699124336,
-                    "z": 1.9531701803207397
+                    "z": 2.6690080165863037
                 },
                 "rotation": {
                     "x": -0.0,

--- a/Assets/Scenes/Decal/DecalDemo.scene
+++ b/Assets/Scenes/Decal/DecalDemo.scene
@@ -11,6 +11,8 @@
                     "y": 0.75,
                     "z": 0.7799999713897705
                 },
+                "envDiffuseStrength": 1.0,
+                "envSpecularStrength": 1.0,
                 "metalness": 0.0,
                 "normalStrength": 1.0,
                 "outlineColor": {
@@ -81,6 +83,8 @@
                     "y": 0.25999999046325684,
                     "z": 0.30000001192092896
                 },
+                "envDiffuseStrength": 1.0,
+                "envSpecularStrength": 1.0,
                 "metalness": 0.0,
                 "normalStrength": 1.0,
                 "outlineColor": {
@@ -226,6 +230,8 @@
                     "y": 0.699999988079071,
                     "z": 0.699999988079071
                 },
+                "envDiffuseStrength": 1.0,
+                "envSpecularStrength": 1.0,
                 "metalness": 0.0,
                 "normalStrength": 1.0,
                 "outlineColor": {
@@ -291,13 +297,13 @@
                 "enabled": true,
                 "position": {
                     "x": 6.8980817794799805,
-                    "y": 11.307735443115234,
+                    "y": 1.2260907888412476,
                     "z": 7.324047088623047
                 },
                 "rotation": {
-                    "x": 1.0030138492584229,
-                    "y": -3.137382984161377,
-                    "z": 0.0035502624232321978
+                    "x": -0.0,
+                    "y": -2.369899034500122,
+                    "z": 0.0
                 },
                 "scale": {
                     "x": 1.0,
@@ -308,6 +314,71 @@
             },
             "guid": "9736660331388967133",
             "name": "MainCamera"
+        },
+        {
+            "Material": {
+                "albedoTexturePath": "",
+                "alpha": 1.0,
+                "ambientOcclusion": 1.0,
+                "assetPath": "Assets/Materials/Tia_Animaition_Run,Rolling,IDLE,Turn,Attack_0.mat",
+                "color": {
+                    "x": 0.699999988079071,
+                    "y": 0.699999988079071,
+                    "z": 0.699999988079071
+                },
+                "envDiffuseStrength": 0.5799999833106995,
+                "envSpecularStrength": 0.8700000047683716,
+                "metalness": 0.0,
+                "normalStrength": 1.0,
+                "outlineColor": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "outlineWidth": 0.0,
+                "roughness": 0.5,
+                "shadingMode": 7,
+                "toonPbrBlur": true,
+                "toonPbrCut1": 0.11900000274181366,
+                "toonPbrCut2": 0.257999986410141,
+                "toonPbrCut3": 0.40700000524520874,
+                "toonPbrLevel1": 0.0,
+                "toonPbrLevel2": 0.6800000071525574,
+                "toonPbrLevel3": 0.9480000138282776,
+                "toonPbrStrength": 0.968999981880188,
+                "transparent": false
+            },
+            "SkinnedAnimation": {
+                "clipIndex": 5,
+                "playing": true,
+                "speed": 1.0,
+                "timeSec": 422.83480867091566
+            },
+            "SkinnedMesh": {
+                "boneCount": 345,
+                "instanceAssetPath": "Assets/Fbx/Tia_Animaition_Run,Rolling,IDLE,Turn,Attack.fbxasset",
+                "meshAssetPath": "Tia_Animaition_Run,Rolling,IDLE,Turn,Attack"
+            },
+            "Transform": {
+                "enabled": true,
+                "position": {
+                    "x": 2.1910400390625,
+                    "y": 0.03142665699124336,
+                    "z": 1.9531701803207397
+                },
+                "rotation": {
+                    "x": -0.0,
+                    "y": -3.007750988006592,
+                    "z": 0.0
+                },
+                "scale": {
+                    "x": 2.0,
+                    "y": 2.0,
+                    "z": 2.0
+                },
+                "visible": true
+            },
+            "guid": "16486367339125333052"
         }
     ],
     "sceneName": "DecalDemo",

--- a/Engine/src/Editor/Core/ReflectionUI.h
+++ b/Engine/src/Editor/Core/ReflectionUI.h
@@ -509,7 +509,8 @@ namespace Alice
 					event = Detail::RenderPropertyWithRange(prop, inst, 0.0f, 5.0f, "", world);
 				}
 				else if (propName == "toonPbrCut1" || propName == "toonPbrCut2" || propName == "toonPbrCut3" ||
-					propName == "toonPbrLevel1" || propName == "toonPbrLevel2" || propName == "toonPbrLevel3")
+					propName == "toonPbrLevel1" || propName == "toonPbrLevel2" || propName == "toonPbrLevel3" ||
+					propName == "toonPbrLevel1Alpha" || propName == "toonPbrLevel2Alpha" || propName == "toonPbrLevel3Alpha")
 				{
 					event = Detail::RenderPropertyWithRange(prop, inst, 0.0f, 1.0f, "", world);
 				}
@@ -584,7 +585,8 @@ namespace Alice
 					event = Detail::RenderPropertyWithRange(prop, inst, 0.0f, 5.0f, displayLabel, world);
 				}
 				else if (propName == "toonPbrCut1" || propName == "toonPbrCut2" || propName == "toonPbrCut3" ||
-					propName == "toonPbrLevel1" || propName == "toonPbrLevel2" || propName == "toonPbrLevel3")
+					propName == "toonPbrLevel1" || propName == "toonPbrLevel2" || propName == "toonPbrLevel3" ||
+					propName == "toonPbrLevel1Alpha" || propName == "toonPbrLevel2Alpha" || propName == "toonPbrLevel3Alpha")
 				{
 					event = Detail::RenderPropertyWithRange(prop, inst, 0.0f, 1.0f, displayLabel, world);
 				}

--- a/Engine/src/Editor/Core/ReflectionUI.h
+++ b/Engine/src/Editor/Core/ReflectionUI.h
@@ -499,7 +499,7 @@ namespace Alice
 
 				// 그 외 프로퍼티는 자동으로 렌더링
 				UIEditEvent event;
-				if (propName == "roughness" || propName == "metalness" || propName == "alpha")
+				if (propName == "roughness" || propName == "metalness" || propName == "alpha" || propName == "shadowStrength")
 				{
 					event = Detail::RenderPropertyWithRange(prop, inst, 0.0f, 1.0f, "", world);
 				}
@@ -576,7 +576,7 @@ namespace Alice
 
 				// roughness, metalness는 자동으로 SliderFloat로 렌더링
 				UIEditEvent event;
-				if (propName == "roughness" || propName == "metalness" || propName == "alpha")
+				if (propName == "roughness" || propName == "metalness" || propName == "alpha" || propName == "shadowStrength")
 				{
 					event = Detail::RenderPropertyWithRange(prop, inst, 0.0f, 1.0f, displayLabel, world);
 				}

--- a/Engine/src/Editor/Inspector/Inspector_Rendering.cpp
+++ b/Engine/src/Editor/Inspector/Inspector_Rendering.cpp
@@ -21,7 +21,8 @@ namespace Alice
 		{
 			// assetPath/albedoTexturePath/shadingMode는 특별 UI 처리하므로 제외
 			return propName != "assetPath" && propName != "albedoTexturePath" && propName != "shadingMode" &&
-			       propName != "shadowStrength" && propName != "toonPbrRampIntensity";
+			       propName != "shadowStrength" && propName != "toonPbrRampIntensity" &&
+			       propName != "toonSelfShadowStrength";
 		}
 	}
 
@@ -81,6 +82,15 @@ namespace Alice
 				if (ImGui::SliderFloat("Toon Ramp Intensity", &toonRamp, 0.0f, 1.0f, "%.3f"))
 				{
 					mat->toonPbrRampIntensity = std::clamp(toonRamp, 0.0f, 1.0f);
+					changed = true;
+				}
+			}
+			// Toon Self Shadow (커스텀 UI)
+			{
+				float toonSelfShadow = mat->toonSelfShadowStrength;
+				if (ImGui::SliderFloat("Toon Self Shadow", &toonSelfShadow, 0.0f, 1.0f, "%.3f"))
+				{
+					mat->toonSelfShadowStrength = std::clamp(toonSelfShadow, 0.0f, 1.0f);
 					changed = true;
 				}
 			}

--- a/Engine/src/Editor/Inspector/Inspector_Rendering.cpp
+++ b/Engine/src/Editor/Inspector/Inspector_Rendering.cpp
@@ -20,7 +20,8 @@ namespace Alice
 		inline bool MaterialInspectorFilter(const std::string& propName)
 		{
 			// assetPath/albedoTexturePath/shadingMode는 특별 UI 처리하므로 제외
-			return propName != "assetPath" && propName != "albedoTexturePath" && propName != "shadingMode";
+			return propName != "assetPath" && propName != "albedoTexturePath" && propName != "shadingMode" &&
+			       propName != "shadowStrength" && propName != "toonPbrRampIntensity";
 		}
 	}
 
@@ -65,6 +66,25 @@ namespace Alice
 				}
 				ImGui::EndDragDropTarget();
 			}
+			// Shadow Intensity (커스텀 UI)
+			{
+				float shadowIntensity = mat->shadowStrength;
+				if (ImGui::SliderFloat("Shadow Intensity", &shadowIntensity, 0.0f, 1.0f, "%.3f"))
+				{
+					mat->shadowStrength = std::clamp(shadowIntensity, 0.0f, 1.0f);
+					changed = true;
+				}
+			}
+			// Toon Ramp Intensity (커스텀 UI)
+			{
+				float toonRamp = mat->toonPbrRampIntensity;
+				if (ImGui::SliderFloat("Toon Ramp Intensity", &toonRamp, 0.0f, 1.0f, "%.3f"))
+				{
+					mat->toonPbrRampIntensity = std::clamp(toonRamp, 0.0f, 1.0f);
+					changed = true;
+				}
+			}
+
 			changed |= ReflectionUI::RenderInspector(*mat, MaterialInspectorFilter).changed;
 
 			struct ShadingItem

--- a/Engine/src/Editor/Panels/LightingPanel.cpp
+++ b/Engine/src/Editor/Panels/LightingPanel.cpp
@@ -163,10 +163,27 @@ namespace Alice
 				&lighting.shadowStrength,
 				0.0f,
 				1.0f);
-			lightingChanged |= Alice::ImGuiSliderFloat(L"Toon Shadow Strength (Editable)",
-				&lighting.toonShadowStrength,
-				0.0f,
-				1.0f);
+
+			bool shadowQualityChanged = false;
+			ShadowSettings shadowSettings = forward.GetShadowSettings();
+			int shadowMapSize = static_cast<int>(shadowSettings.mapSizePx);
+			float shadowPcfRadius = shadowSettings.pcfRadius;
+
+			shadowQualityChanged |= ImGui::SliderInt("Shadow Map Size", &shadowMapSize, 512, 8192);
+			shadowQualityChanged |= ImGui::SliderFloat("Shadow PCF Radius", &shadowPcfRadius, 0.0f, 3.0f, "%.2f");
+
+			if (shadowQualityChanged)
+			{
+				// Snap to reasonable increments for stability
+				shadowMapSize = (shadowMapSize / 256) * 256;
+				shadowMapSize = (std::max)(512, shadowMapSize);
+
+				shadowSettings.mapSizePx = static_cast<std::uint32_t>(shadowMapSize);
+				shadowSettings.pcfRadius = std::clamp(shadowPcfRadius, 0.0f, 3.0f);
+
+				forward.ApplyShadowSettings(shadowSettings);
+				deferred.ApplyShadowSettings(shadowSettings);
+			}
 
 			if (lightingChanged)
 			{

--- a/Engine/src/Editor/Panels/LightingPanel.cpp
+++ b/Engine/src/Editor/Panels/LightingPanel.cpp
@@ -156,6 +156,17 @@ namespace Alice
 				&lighting.keyDirection.x,
 				-1.0f,
 				1.0f);
+			
+			ImGui::Separator();
+			ImGui::TextUnformatted("Shadow");
+			lightingChanged |= Alice::ImGuiSliderFloat(L"Shadow Strength",
+				&lighting.shadowStrength,
+				0.0f,
+				1.0f);
+			lightingChanged |= Alice::ImGuiSliderFloat(L"Toon Shadow Strength (Editable)",
+				&lighting.toonShadowStrength,
+				0.0f,
+				1.0f);
 
 			if (lightingChanged)
 			{

--- a/Engine/src/Editor/Panels/LightingPanel.cpp
+++ b/Engine/src/Editor/Panels/LightingPanel.cpp
@@ -10,6 +10,7 @@
 #include "imgui.h"
 
 #include <algorithm>
+#include <cmath>
 #include <cstring>
 #include <filesystem>
 #include <DirectXMath.h>
@@ -87,6 +88,68 @@ namespace Alice
 
 			return {};
 		}
+
+		constexpr float kPi = 3.14159265358979323846f;
+		constexpr float kDegToRad = kPi / 180.0f;
+		constexpr float kRadToDeg = 180.0f / kPi;
+
+		DirectX::XMFLOAT3 NormalizeDirectionSafe(const DirectX::XMFLOAT3& dir)
+		{
+			using namespace DirectX;
+			const XMVECTOR v = XMLoadFloat3(&dir);
+			const float lenSq = XMVectorGetX(XMVector3LengthSq(v));
+			if (lenSq <= 1e-8f)
+			{
+				return XMFLOAT3(0.0f, -1.0f, 0.0f);
+			}
+			XMFLOAT3 out;
+			XMStoreFloat3(&out, XMVector3Normalize(v));
+			return out;
+		}
+
+		bool NearlyEqualDirection(const DirectX::XMFLOAT3& a, const DirectX::XMFLOAT3& b, float eps = 1e-4f)
+		{
+			return (std::fabs(a.x - b.x) <= eps) &&
+				(std::fabs(a.y - b.y) <= eps) &&
+				(std::fabs(a.z - b.z) <= eps);
+		}
+
+		void DirectionToYawPitchDeg(const DirectX::XMFLOAT3& direction, float& outYawDeg, float& outPitchDeg)
+		{
+			const DirectX::XMFLOAT3 d = NormalizeDirectionSafe(direction);
+			outYawDeg = std::atan2(d.x, -d.z) * kRadToDeg;
+			const float y = std::clamp(-d.y, -1.0f, 1.0f);
+			outPitchDeg = std::asin(y) * kRadToDeg;
+		}
+
+		DirectX::XMFLOAT3 YawPitchRollDegToDirection(float yawDeg, float pitchDeg, float rollDeg)
+		{
+			using namespace DirectX;
+			const float yaw = yawDeg * kDegToRad;
+			const float pitch = pitchDeg * kDegToRad;
+			const float roll = rollDeg * kDegToRad;
+			const XMMATRIX rot = XMMatrixRotationRollPitchYaw(pitch, yaw, roll);
+			const XMVECTOR forward = XMVectorSet(0.0f, 0.0f, -1.0f, 0.0f);
+			XMFLOAT3 out;
+			XMStoreFloat3(&out, XMVector3Normalize(XMVector3TransformNormal(forward, rot)));
+			return out;
+		}
+
+		bool DragWithInputAngle(const char* label, float& value, float minValue, float maxValue, float dragSpeed = 0.25f)
+		{
+			bool changed = false;
+			ImGui::PushID(label);
+			ImGui::SetNextItemWidth(170.0f);
+			changed |= ImGui::DragFloat("##drag", &value, dragSpeed, minValue, maxValue, "%.2f");
+			ImGui::SameLine();
+			ImGui::SetNextItemWidth(100.0f);
+			changed |= ImGui::InputFloat("##input", &value, 0.0f, 0.0f, "%.2f");
+			ImGui::SameLine();
+			ImGui::TextUnformatted(label);
+			ImGui::PopID();
+			value = std::clamp(value, minValue, maxValue);
+			return changed;
+		}
 	}
 
 	void EditorCore::DrawLightingWindow(World& world,
@@ -134,6 +197,7 @@ namespace Alice
 				ImGui::Separator();
 				ImGui::Text("PBR Material Parameters");
 				lightingChanged |= ImGui::ColorEdit3("Base Color", &lighting.baseColor.x);
+				lightingChanged |= ImGui::ColorEdit3("Key Light Color", &lighting.diffuseColor.x);
 				lightingChanged |= ImGui::SliderFloat("Metalness", &lighting.metalness, 0.0f, 1.0f);
 				lightingChanged |= ImGui::SliderFloat("Roughness", &lighting.roughness, 0.0f, 1.0f);
 				lightingChanged |= ImGui::SliderFloat("Ambient Occlusion", &lighting.ambientOcclusion, 0.0f, 1.0f);
@@ -152,10 +216,35 @@ namespace Alice
 				&lighting.keyIntensity,
 				0.0f,
 				3.0f);
-			lightingChanged |= Alice::ImGuiSliderFloat3(L"Key Direction (주광)",
-				&lighting.keyDirection.x,
-				-1.0f,
-				1.0f);
+			ImGui::TextUnformatted("Key Rotation (Euler)");
+			static bool keyEulerInit = false;
+			static DirectX::XMFLOAT3 lastKeyDirection = { 0.0f, -1.0f, 0.0f };
+			static float keyYawDeg = 0.0f;
+			static float keyPitchDeg = 0.0f;
+			static float keyRollDeg = 0.0f;
+
+			const DirectX::XMFLOAT3 normalizedKeyDir = NormalizeDirectionSafe(lighting.keyDirection);
+			if (!keyEulerInit || !NearlyEqualDirection(normalizedKeyDir, lastKeyDirection))
+			{
+				DirectionToYawPitchDeg(normalizedKeyDir, keyYawDeg, keyPitchDeg);
+				lastKeyDirection = normalizedKeyDir;
+				keyEulerInit = true;
+			}
+
+			bool keyDirectionChanged = false;
+			keyDirectionChanged |= DragWithInputAngle("Yaw (deg)", keyYawDeg, -180.0f, 180.0f);
+			keyDirectionChanged |= DragWithInputAngle("Pitch (deg)", keyPitchDeg, -89.9f, 89.9f);
+			keyDirectionChanged |= DragWithInputAngle("Roll (deg)", keyRollDeg, -180.0f, 180.0f);
+
+			if (keyDirectionChanged)
+			{
+				lighting.keyDirection = YawPitchRollDegToDirection(keyYawDeg, keyPitchDeg, keyRollDeg);
+				lastKeyDirection = lighting.keyDirection;
+				lightingChanged = true;
+			}
+
+			ImGui::Text("Key Direction Vector: %.3f, %.3f, %.3f",
+				lighting.keyDirection.x, lighting.keyDirection.y, lighting.keyDirection.z);
 			
 			ImGui::Separator();
 			ImGui::TextUnformatted("Shadow");
@@ -183,6 +272,27 @@ namespace Alice
 
 				forward.ApplyShadowSettings(shadowSettings);
 				deferred.ApplyShadowSettings(shadowSettings);
+			}
+
+			ImGui::Separator();
+			ImGui::TextUnformatted("Tone Mapping");
+			float tmExposure = 0.0f;
+			float tmMaxNits = 1000.0f;
+			float tmSaturation = 1.0f;
+			float tmContrast = 1.0f;
+			float tmGamma = 1.0f;
+			forward.GetPostProcessParams(tmExposure, tmMaxNits, tmSaturation, tmContrast, tmGamma);
+
+			bool toneMappingChanged = false;
+			toneMappingChanged |= ImGui::SliderFloat("Exposure", &tmExposure, -5.0f, 5.0f, "%.2f");
+			toneMappingChanged |= ImGui::SliderFloat("Saturation", &tmSaturation, 0.0f, 3.0f, "%.2f");
+			toneMappingChanged |= ImGui::SliderFloat("Contrast", &tmContrast, 0.0f, 2.0f, "%.2f");
+			toneMappingChanged |= ImGui::SliderFloat("Gamma", &tmGamma, 0.1f, 3.0f, "%.2f");
+
+			if (toneMappingChanged)
+			{
+				forward.SetPostProcessParams(tmExposure, tmMaxNits, tmSaturation, tmContrast, tmGamma);
+				deferred.SetPostProcessParams(tmExposure, tmMaxNits, tmSaturation, tmContrast, tmGamma);
 			}
 
 			if (lightingChanged)

--- a/Engine/src/Runtime/ECS/ComponentRegistry.cpp
+++ b/Engine/src/Runtime/ECS/ComponentRegistry.cpp
@@ -182,7 +182,8 @@ namespace Alice
             .property("toonPbrLevel3Alpha", &MaterialComponent::toonPbrLevel3Alpha)
             .property("toonPbrStrength", &MaterialComponent::toonPbrStrength)
             .property("toonPbrBlur", &MaterialComponent::toonPbrBlur)
-            .property("toonPbrRampIntensity", &MaterialComponent::toonPbrRampIntensity);
+            .property("toonPbrRampIntensity", &MaterialComponent::toonPbrRampIntensity)
+            .property("toonSelfShadowStrength", &MaterialComponent::toonSelfShadowStrength);
 
         // === DecalComponent 등록 ===
         rttr::registration::class_<DecalComponent>("DecalComponent")

--- a/Engine/src/Runtime/ECS/ComponentRegistry.cpp
+++ b/Engine/src/Runtime/ECS/ComponentRegistry.cpp
@@ -181,7 +181,8 @@ namespace Alice
             .property("toonPbrLevel2Alpha", &MaterialComponent::toonPbrLevel2Alpha)
             .property("toonPbrLevel3Alpha", &MaterialComponent::toonPbrLevel3Alpha)
             .property("toonPbrStrength", &MaterialComponent::toonPbrStrength)
-            .property("toonPbrBlur", &MaterialComponent::toonPbrBlur);
+            .property("toonPbrBlur", &MaterialComponent::toonPbrBlur)
+            .property("toonPbrRampIntensity", &MaterialComponent::toonPbrRampIntensity);
 
         // === DecalComponent 등록 ===
         rttr::registration::class_<DecalComponent>("DecalComponent")

--- a/Engine/src/Runtime/ECS/ComponentRegistry.cpp
+++ b/Engine/src/Runtime/ECS/ComponentRegistry.cpp
@@ -161,6 +161,7 @@ namespace Alice
             .property("roughness", &MaterialComponent::roughness)
             .property("metalness", &MaterialComponent::metalness)
             .property("ambientOcclusion", &MaterialComponent::ambientOcclusion)
+            .property("shadowStrength", &MaterialComponent::shadowStrength)
             .property("envDiffuseStrength", &MaterialComponent::envDiffuseStrength)
             .property("envSpecularStrength", &MaterialComponent::envSpecularStrength)
             .property("shadingMode", &MaterialComponent::shadingMode)

--- a/Engine/src/Runtime/ECS/ComponentRegistry.cpp
+++ b/Engine/src/Runtime/ECS/ComponentRegistry.cpp
@@ -176,6 +176,9 @@ namespace Alice
             .property("toonPbrLevel1", &MaterialComponent::toonPbrLevel1)
             .property("toonPbrLevel2", &MaterialComponent::toonPbrLevel2)
             .property("toonPbrLevel3", &MaterialComponent::toonPbrLevel3)
+            .property("toonPbrLevel1Alpha", &MaterialComponent::toonPbrLevel1Alpha)
+            .property("toonPbrLevel2Alpha", &MaterialComponent::toonPbrLevel2Alpha)
+            .property("toonPbrLevel3Alpha", &MaterialComponent::toonPbrLevel3Alpha)
             .property("toonPbrStrength", &MaterialComponent::toonPbrStrength)
             .property("toonPbrBlur", &MaterialComponent::toonPbrBlur);
 

--- a/Engine/src/Runtime/Engine/EngineInitialize.cpp
+++ b/Engine/src/Runtime/Engine/EngineInitialize.cpp
@@ -2,6 +2,7 @@
 #include "Runtime/ECS/Components/TransformComponent.h"
 #include "Runtime/Resources/Prefab.h"
 #include <Windows.h>
+#include <algorithm>
 #include <chrono>
 #include <thread>
 
@@ -177,6 +178,12 @@ namespace Alice
 						lighting.roughness = p["roughness"].get<float>();
 					if (p.contains("ambientOcclusion") && p["ambientOcclusion"].is_number())
 						lighting.ambientOcclusion = p["ambientOcclusion"].get<float>();
+					if (p.contains("shadowStrength") && p["shadowStrength"].is_number())
+						lighting.shadowStrength = p["shadowStrength"].get<float>();
+					if (p.contains("toonShadowStrength") && p["toonShadowStrength"].is_number())
+						lighting.toonShadowStrength = p["toonShadowStrength"].get<float>();
+					lighting.shadowStrength = std::clamp(lighting.shadowStrength, 0.0f, 1.0f);
+					lighting.toonShadowStrength = std::clamp(lighting.toonShadowStrength, 0.0f, 1.0f);
 
 					if (p.contains("keyIntensity") && p["keyIntensity"].is_number())
 						lighting.keyIntensity = p["keyIntensity"].get<float>();
@@ -242,6 +249,8 @@ namespace Alice
 			p["metalness"] = lighting.metalness;
 			p["roughness"] = lighting.roughness;
 			p["ambientOcclusion"] = lighting.ambientOcclusion;
+			p["shadowStrength"] = lighting.shadowStrength;
+			p["toonShadowStrength"] = lighting.toonShadowStrength;
 			p["keyIntensity"] = lighting.keyIntensity;
 			p["fillIntensity"] = lighting.fillIntensity;
 			p["keyDirection"] = Vec3ToJson(lighting.keyDirection);

--- a/Engine/src/Runtime/Gameplay/Animation/SkinnedMeshSystem.h
+++ b/Engine/src/Runtime/Gameplay/Animation/SkinnedMeshSystem.h
@@ -132,6 +132,7 @@ namespace Alice
                     cmd.toonPbrCuts = DirectX::XMFLOAT4(mat->toonPbrCut1, mat->toonPbrCut2, mat->toonPbrCut3, mat->toonPbrStrength);
                     cmd.toonPbrLevels = DirectX::XMFLOAT4(mat->toonPbrLevel1, mat->toonPbrLevel2, mat->toonPbrLevel3,
                                                           mat->toonPbrBlur ? 1.0f : 0.0f);
+                    cmd.toonPbrAlphas = DirectX::XMFLOAT4(mat->toonPbrLevel1Alpha, mat->toonPbrLevel2Alpha, mat->toonPbrLevel3Alpha, 0.0f);
 
                     if (!mat->albedoTexturePath.empty())
                     {

--- a/Engine/src/Runtime/Gameplay/Animation/SkinnedMeshSystem.h
+++ b/Engine/src/Runtime/Gameplay/Animation/SkinnedMeshSystem.h
@@ -132,7 +132,7 @@ namespace Alice
                     cmd.toonPbrCuts = DirectX::XMFLOAT4(mat->toonPbrCut1, mat->toonPbrCut2, mat->toonPbrCut3, mat->toonPbrStrength);
                     cmd.toonPbrLevels = DirectX::XMFLOAT4(mat->toonPbrLevel1, mat->toonPbrLevel2, mat->toonPbrLevel3,
                                                           mat->toonPbrBlur ? 1.0f : 0.0f);
-                    cmd.toonPbrAlphas = DirectX::XMFLOAT4(mat->toonPbrLevel1Alpha, mat->toonPbrLevel2Alpha, mat->toonPbrLevel3Alpha, 0.0f);
+                    cmd.toonPbrAlphas = DirectX::XMFLOAT4(mat->toonPbrLevel1Alpha, mat->toonPbrLevel2Alpha, mat->toonPbrLevel3Alpha, mat->shadowStrength);
 
                     if (!mat->albedoTexturePath.empty())
                     {

--- a/Engine/src/Runtime/Gameplay/Animation/SkinnedMeshSystem.h
+++ b/Engine/src/Runtime/Gameplay/Animation/SkinnedMeshSystem.h
@@ -133,6 +133,7 @@ namespace Alice
                     cmd.toonPbrLevels = DirectX::XMFLOAT4(mat->toonPbrLevel1, mat->toonPbrLevel2, mat->toonPbrLevel3,
                                                           mat->toonPbrBlur ? 1.0f : 0.0f);
                     cmd.toonPbrAlphas = DirectX::XMFLOAT4(mat->toonPbrLevel1Alpha, mat->toonPbrLevel2Alpha, mat->toonPbrLevel3Alpha, mat->shadowStrength);
+                    cmd.toonPbrRampIntensity = mat->toonPbrRampIntensity;
 
                     if (!mat->albedoTexturePath.empty())
                     {

--- a/Engine/src/Runtime/Gameplay/Animation/SkinnedMeshSystem.h
+++ b/Engine/src/Runtime/Gameplay/Animation/SkinnedMeshSystem.h
@@ -134,6 +134,7 @@ namespace Alice
                                                           mat->toonPbrBlur ? 1.0f : 0.0f);
                     cmd.toonPbrAlphas = DirectX::XMFLOAT4(mat->toonPbrLevel1Alpha, mat->toonPbrLevel2Alpha, mat->toonPbrLevel3Alpha, mat->shadowStrength);
                     cmd.toonPbrRampIntensity = mat->toonPbrRampIntensity;
+                    cmd.toonSelfShadowStrength = mat->toonSelfShadowStrength;
 
                     if (!mat->albedoTexturePath.empty())
                     {

--- a/Engine/src/Runtime/Importing/FbxImporter.cpp
+++ b/Engine/src/Runtime/Importing/FbxImporter.cpp
@@ -74,6 +74,72 @@ namespace Alice
             return (std::filesystem::path("Resource") / std::filesystem::path(rel)).generic_string();
         }
 
+        inline bool IsFbmDir(const std::filesystem::path& p)
+        {
+            std::string ext = p.extension().string();
+            ToLowerInPlace(ext);
+            return ext == ".fbm";
+        }
+
+        inline std::filesystem::path ResolveSourceTexturePath(const std::filesystem::path& fbxPath, std::string rawPath)
+        {
+            namespace fs = std::filesystem;
+
+            if (rawPath.empty())
+                return {};
+
+            std::replace(rawPath.begin(), rawPath.end(), '\\', '/');
+
+            // Blender/Assimp 상대 경로 패턴("//textures/...")
+            bool blenderStyleRelative = false;
+            if (rawPath.size() >= 2 && rawPath[0] == '/' && rawPath[1] == '/')
+            {
+                rawPath = rawPath.substr(2);
+                blenderStyleRelative = true;
+            }
+
+            fs::path src = fs::path(rawPath);
+            if (blenderStyleRelative || !src.is_absolute())
+            {
+                src = (fbxPath.parent_path() / src).lexically_normal();
+            }
+
+            if (fs::exists(src))
+            {
+                return src;
+            }
+
+            // FBX와 함께 생성되는 *.fbm 폴더에서 파일명 기준 탐색
+            const fs::path fileOnly = fs::path(rawPath).filename();
+            if (fileOnly.empty())
+            {
+                return {};
+            }
+
+            std::error_code ec;
+            const fs::path parent = fbxPath.parent_path();
+            for (const auto& entry : fs::directory_iterator(parent, ec))
+            {
+                if (ec) break;
+                if (!entry.is_directory(ec)) continue;
+                if (!IsFbmDir(entry.path())) continue;
+                fs::path candidate = entry.path() / fileOnly;
+                if (fs::exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            // 마지막 폴백: FBX 폴더 바로 아래 파일명만으로 탐색
+            fs::path sibling = parent / fileOnly;
+            if (fs::exists(sibling))
+            {
+                return sibling;
+            }
+
+            return {};
+        }
+
         static void AppendSkeletonText(const std::vector<FbxSkeletonNode>& nodes,
                                        int idx,
                                        int depth,
@@ -164,14 +230,13 @@ namespace Alice
             else
             {
                 // 외부 파일 복사 (존재하지 않을 때만)
-                fs::path srcAbsPath = rawPath;
-                if (!srcAbsPath.is_absolute())
-                {
-                    srcAbsPath = fbxPath.parent_path() / rawPath;
-                    srcAbsPath = srcAbsPath.lexically_normal();
-                }
+                fs::path srcAbsPath = ResolveSourceTexturePath(fbxPath, rawPath);
 
-                if (fs::exists(srcAbsPath) && !fs::exists(finalAbsPath))
+                if (fs::exists(finalAbsPath))
+                {
+                    // 이미 추출/복사된 텍스처가 있으면 재사용
+                }
+                else if (fs::exists(srcAbsPath))
                 {
                     fs::copy_file(srcAbsPath, finalAbsPath, fs::copy_options::overwrite_existing, ec);
                     if (ec)
@@ -180,6 +245,12 @@ namespace Alice
                             srcAbsPath.string().c_str(), finalAbsPath.string().c_str(), ec.message().c_str());
                         return {};
                     }
+                }
+                else
+                {
+                    ALICE_LOG_WARN("[FbxImporter] ProcessTexture: source texture not found \"%s\" (fbx=\"%s\")",
+                        rawPath.c_str(), fbxPath.string().c_str());
+                    return {};
                 }
             }
 
@@ -324,7 +395,7 @@ namespace Alice
         //    쿠킹은 하지 않음 (전역 빌드 프로세스가 Resource 폴더를 청크로 변환)
         //    텍스처는 FBX 파일의 실제 위치를 기준으로 찾아야 하므로 resolved 경로 사용
         int embeddedCounter = 0;
-        std::vector<std::string> textureLogicalPaths;
+        std::vector<std::string> materialAlbedoPaths(scene->mNumMaterials);
 
         // 각 머티리얼에서 텍스처 추출 및 저장
         for (unsigned mi = 0; mi < scene->mNumMaterials; ++mi)
@@ -336,9 +407,8 @@ namespace Alice
             std::string albedoPath = ProcessTexture(m_resources, scene, mat, aiTextureType_DIFFUSE, resolved, baseName, "D", embeddedCounter);
             if (albedoPath.empty())
                 albedoPath = ProcessTexture(m_resources, scene, mat, aiTextureType_BASE_COLOR, resolved, baseName, "D", embeddedCounter);
-            
-            if (!albedoPath.empty())
-                textureLogicalPaths.push_back(albedoPath);
+
+            materialAlbedoPaths[mi] = std::move(albedoPath);
         }
 
         // 4) .mat 파일 생성 (서브셋 개수만큼)
@@ -354,15 +424,20 @@ namespace Alice
             fs::path matPath = matDir / (baseName + "_" + std::to_string(i) + ".mat");
 
             MaterialComponent matComp;
-            matComp.color = DirectX::XMFLOAT3(0.7f, 0.7f, 0.7f);
+            matComp.color = DirectX::XMFLOAT3(1.0f, 1.0f, 1.0f);
             matComp.roughness = 0.5f;
             matComp.metalness = 0.0f;
             matComp.assetPath = matPath.string();
             
-            // 첫 번째 텍스처를 albedo로 사용 (서브셋별로 매핑 가능하지만 현재는 단순화)
-            if (i < textureLogicalPaths.size())
+            // 서브셋의 materialIndex를 기준으로 알베도 텍스처를 매핑합니다.
+            std::size_t sourceMatIndex = i;
+            if (!subsets.empty() && i < subsets.size())
             {
-                matComp.albedoTexturePath = textureLogicalPaths[i];
+                sourceMatIndex = static_cast<std::size_t>(subsets[i].materialIndex);
+            }
+            if (sourceMatIndex < materialAlbedoPaths.size())
+            {
+                matComp.albedoTexturePath = materialAlbedoPaths[sourceMatIndex];
             }
 
             MaterialFile::Save(matPath, matComp);

--- a/Engine/src/Runtime/Importing/FbxMaterial.cpp
+++ b/Engine/src/Runtime/Importing/FbxMaterial.cpp
@@ -9,6 +9,8 @@
 #include <assimp/scene.h>
 #include <assimp/Importer.hpp>
 #include <filesystem>
+#include <cstdint>
+#include <vector>
 
 using Microsoft::WRL::ComPtr;
 
@@ -81,6 +83,110 @@ static void AddCache(std::unordered_map<std::wstring, ID3D11ShaderResourceView*>
 	if (v) { cache[key] = v; v->AddRef(); }
 }
 
+static bool IsColorTextureType(aiTextureType texType)
+{
+	return texType == aiTextureType_DIFFUSE ||
+		   texType == aiTextureType_BASE_COLOR ||
+		   texType == aiTextureType_EMISSIVE;
+}
+
+static DirectX::WIC_LOADER_FLAGS GetWicFlagsForTextureType(aiTextureType texType)
+{
+	return IsColorTextureType(texType)
+		? DirectX::WIC_LOADER_FORCE_SRGB
+		: DirectX::WIC_LOADER_IGNORE_SRGB;
+}
+
+static bool IsDDSBytes(const std::vector<std::uint8_t>& data)
+{
+	return data.size() >= 4 &&
+		   data[0] == 'D' &&
+		   data[1] == 'D' &&
+		   data[2] == 'S' &&
+		   data[3] == ' ';
+}
+
+static ID3D11ShaderResourceView* CreateSRVFromMemoryWithType(
+	ID3D11Device* device,
+	const std::uint8_t* bytes,
+	std::size_t byteSize,
+	aiTextureType texType)
+{
+	if (!device || !bytes || byteSize == 0)
+		return nullptr;
+
+	const bool forceSrgb = IsColorTextureType(texType);
+	const std::vector<std::uint8_t> data(bytes, bytes + byteSize);
+	ComPtr<ID3D11ShaderResourceView> srv;
+	HRESULT hr = E_FAIL;
+
+	if (IsDDSBytes(data))
+	{
+		const auto ddsFlags = forceSrgb
+			? DirectX::DDS_LOADER_FORCE_SRGB
+			: DirectX::DDS_LOADER_DEFAULT;
+		hr = DirectX::CreateDDSTextureFromMemoryEx(
+			device,
+			data.data(),
+			data.size(),
+			0,
+			D3D11_USAGE_DEFAULT,
+			D3D11_BIND_SHADER_RESOURCE,
+			0,
+			0,
+			ddsFlags,
+			nullptr,
+			srv.ReleaseAndGetAddressOf());
+	}
+	else
+	{
+		ComPtr<ID3D11DeviceContext> ctx;
+		device->GetImmediateContext(ctx.GetAddressOf());
+		ComPtr<ID3D11Resource> res;
+
+		hr = DirectX::CreateWICTextureFromMemoryEx(
+			device,
+			ctx.Get(),
+			data.data(),
+			data.size(),
+			0,
+			D3D11_USAGE_DEFAULT,
+			D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET,
+			0,
+			D3D11_RESOURCE_MISC_GENERATE_MIPS,
+			GetWicFlagsForTextureType(texType),
+			res.GetAddressOf(),
+			srv.ReleaseAndGetAddressOf());
+
+		if (SUCCEEDED(hr) && ctx && srv)
+		{
+			ctx->GenerateMips(srv.Get());
+		}
+		else if (FAILED(hr))
+		{
+			hr = DirectX::CreateWICTextureFromMemoryEx(
+				device,
+				ctx.Get(),
+				data.data(),
+				data.size(),
+				0,
+				D3D11_USAGE_DEFAULT,
+				D3D11_BIND_SHADER_RESOURCE,
+				0,
+				0,
+				GetWicFlagsForTextureType(texType),
+				nullptr,
+				srv.ReleaseAndGetAddressOf());
+		}
+	}
+
+	if (FAILED(hr) || !srv)
+		return nullptr;
+
+	srv->AddRef();
+	return srv.Get();
+}
+
 // 단색(1x1) 텍스처 SRV 생성 헬퍼
 static void CreateSolidColorSRV(ID3D11Device* device, UINT rgba, ID3D11ShaderResourceView** outSRV)
 {
@@ -114,33 +220,30 @@ static void CreateSolidColorSRV(ID3D11Device* device, UINT rgba, ID3D11ShaderRes
 // aiTexture(임베디드 텍스처)로부터 SRV 생성
 static ID3D11ShaderResourceView* CreateSRVFromEmbedded(
 	ID3D11Device* device,
-	const aiTexture* at)
+	const aiTexture* at,
+	aiTextureType texType)
 {
 	if (!device || !at) return nullptr;
 
-	ComPtr<ID3D11Resource> res;
-	ID3D11ShaderResourceView* srv = nullptr;
-
 	if (at->mHeight == 0)
 	{
-		if (SUCCEEDED(DirectX::CreateWICTextureFromMemory(
+		return CreateSRVFromMemoryWithType(
 			device,
-			reinterpret_cast<const uint8_t*>(at->pcData),
-			at->mWidth,
-			res.GetAddressOf(),
-			&srv)))
-		{
-			return srv;
-		}
+			reinterpret_cast<const std::uint8_t*>(at->pcData),
+			static_cast<std::size_t>(at->mWidth),
+			texType);
 	}
 	else
 	{
+		ID3D11ShaderResourceView* srv = nullptr;
 		D3D11_TEXTURE2D_DESC td{};
 		td.Width = at->mWidth;
 		td.Height = at->mHeight;
 		td.MipLevels = 1;
 		td.ArraySize = 1;
-		td.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+		td.Format = IsColorTextureType(texType)
+			? DXGI_FORMAT_B8G8R8A8_UNORM_SRGB
+			: DXGI_FORMAT_B8G8R8A8_UNORM;
 		td.SampleDesc.Count = 1;
 		td.Usage = D3D11_USAGE_IMMUTABLE;
 		td.BindFlags = D3D11_BIND_SHADER_RESOURCE;
@@ -167,7 +270,7 @@ static ID3D11ShaderResourceView* CreateSRVFromEmbedded(
 }
 
 
-static HRESULT CreateTextureFromTgaFile(ID3D11Device* device, const wchar_t* path, ID3D11ShaderResourceView** outSRV)
+static HRESULT CreateTextureFromTgaFile(ID3D11Device* device, const wchar_t* path, aiTextureType texType, ID3D11ShaderResourceView** outSRV)
 {
 	if (!device || !path || !outSRV) return E_INVALIDARG;
 	*outSRV = nullptr;
@@ -178,6 +281,11 @@ static HRESULT CreateTextureFromTgaFile(ID3D11Device* device, const wchar_t* pat
 	ScratchImage image;
 	HRESULT hr = LoadFromTGAFile(path, &metadata, image);
 	if (FAILED(hr)) return hr;
+
+	if (IsColorTextureType(texType))
+	{
+		metadata.format = MakeSRGB(metadata.format);
+	}
 
 	hr = CreateShaderResourceView(
 		device,
@@ -192,6 +300,7 @@ static HRESULT CreateTextureFromTgaFile(ID3D11Device* device, const wchar_t* pat
 static HRESULT CreateTextureFromFileWithTga(
 	ID3D11Device* device,
 	const std::wstring& path,
+	aiTextureType texType,
 	ID3D11Resource** outRes,
 	ID3D11ShaderResourceView** outSRV)
 {
@@ -201,7 +310,17 @@ static HRESULT CreateTextureFromFileWithTga(
 	ID3D11Resource** resPtr = outRes ? outRes : dummyRes.GetAddressOf();
 
 	ID3D11ShaderResourceView* srv = nullptr;
-	HRESULT hr = DirectX::CreateWICTextureFromFile(device, path.c_str(), resPtr, &srv);
+	HRESULT hr = DirectX::CreateWICTextureFromFileEx(
+		device,
+		path.c_str(),
+		0,
+		D3D11_USAGE_DEFAULT,
+		D3D11_BIND_SHADER_RESOURCE,
+		0,
+		0,
+		GetWicFlagsForTextureType(texType),
+		resPtr,
+		&srv);
 	if (FAILED(hr))
 	{
 		// 확장자가 .tga 이면 직접 파싱 시도
@@ -210,7 +329,7 @@ static HRESULT CreateTextureFromFileWithTga(
 			std::wstring ext = path.substr(path.size() - 4);
 			if (ext == L".tga" || ext == L".TGA")
 			{
-				hr = CreateTextureFromTgaFile(device, path.c_str(), &srv);
+				hr = CreateTextureFromTgaFile(device, path.c_str(), texType, &srv);
 			}
 		}
 	}
@@ -254,8 +373,8 @@ static ID3D11ShaderResourceView* LoadTextureFromMaterial(
 			const aiTexture* at = scene->GetEmbeddedTexture(texPathStr.c_str());
 			if (at)
 			{
-				// (Embedded 텍스처를 SRV로 변환하는 함수 호출)
-				result = CreateSRVFromEmbedded(device, at);
+				// (Embedded 텍처를 SRV로 변환하는 함수 호출)
+				result = CreateSRVFromEmbedded(device, at, texType);
 			}
 		}
 
@@ -304,7 +423,7 @@ static ID3D11ShaderResourceView* LoadTextureFromMaterial(
 					result = cached;
 					result->AddRef();
 				}
-				else if (SUCCEEDED(CreateTextureFromFileWithTga(device, fullPathW,
+				else if (SUCCEEDED(CreateTextureFromFileWithTga(device, fullPathW, texType,
 					(ID3D11Resource**)nullptr, &result)))
 				{
 					AddCache(cache, fullPathW, result);
@@ -371,7 +490,7 @@ static ID3D11ShaderResourceView* LoadTextureFromMaterialRM(
 			const aiTexture* at = scene->GetEmbeddedTexture(texPathStr.c_str());
 			if (at)
 			{
-				result = CreateSRVFromEmbedded(device, at);
+				result = CreateSRVFromEmbedded(device, at, texType);
 			}
 		}
 
@@ -383,6 +502,8 @@ static ID3D11ShaderResourceView* LoadTextureFromMaterialRM(
 			{
 				// 캐시 키는 논리 경로 문자열
 				std::string cacheKey = logicalTex.generic_string();
+				cacheKey += "|";
+				cacheKey += std::to_string(static_cast<int>(texType));
 				auto it = cache.find(cacheKey);
 				if (it != cache.end())
 				{
@@ -391,12 +512,30 @@ static ID3D11ShaderResourceView* LoadTextureFromMaterialRM(
 				}
 				else
 				{
-					// ResourceManager를 통해 로드
-					auto srv = rm.Load<ID3D11ShaderResourceView>(logicalTex, device);
-					if (srv)
+					// ResourceManager에서 원본 바이트를 읽고 텍스처 타입에 맞는 색공간으로 SRV 생성
+					std::vector<std::uint8_t> data;
+					if (rm.LoadBinaryAuto(logicalTex, data) && !data.empty())
 					{
-						result = srv.Get();
-						result->AddRef();
+						result = CreateSRVFromMemoryWithType(
+							device,
+							data.data(),
+							data.size(),
+							texType);
+					}
+
+					// 바이트 경로 실패 시 기존 로더로 폴백
+					if (!result)
+					{
+						auto srv = rm.Load<ID3D11ShaderResourceView>(logicalTex, device);
+						if (srv)
+						{
+							result = srv.Get();
+							result->AddRef();
+						}
+					}
+
+					if (result)
+					{
 						cache[cacheKey] = result;
 					}
 				}
@@ -437,14 +576,25 @@ bool FbxMaterialLoader::Load(ID3D11Device* device, const aiScene* scene, const s
 	{
 		aiMaterial* mat = scene->mMaterials[m];
 
-		// BaseColor / Diffuse
-		m_->baseColorSRVs[m] = LoadTextureFromMaterialRM(
+		// BaseColor / Diffuse (우선순위: BASE_COLOR > DIFFUSE)
+		ID3D11ShaderResourceView* baseColor = LoadTextureFromMaterialRM(
 			device, scene, mat,
-			aiTextureType_DIFFUSE,          // BaseColor
+			aiTextureType_BASE_COLOR,
 			fbxLogicalPath,
 			rm,
 			logicalCache,
-			m_->white);
+			nullptr);
+		if (!baseColor)
+		{
+			baseColor = LoadTextureFromMaterialRM(
+				device, scene, mat,
+				aiTextureType_DIFFUSE,
+				fbxLogicalPath,
+				rm,
+				logicalCache,
+				m_->white);
+		}
+		m_->baseColorSRVs[m] = baseColor;
 
 		// Normal map
 		m_->normalSRVs[m] = LoadTextureFromMaterialRM(
@@ -498,13 +648,23 @@ bool FbxMaterialLoader::Load(ID3D11Device* device, const aiScene* scene, const s
 	{
 		aiMaterial* mat = scene->mMaterials[m];
 
-		// BaseColor / Diffuse
-		m_->baseColorSRVs[m] = LoadTextureFromMaterial(
+		// BaseColor / Diffuse (우선순위: BASE_COLOR > DIFFUSE)
+		ID3D11ShaderResourceView* baseColor = LoadTextureFromMaterial(
 			device, scene, mat,
-			aiTextureType_DIFFUSE,          // BaseColor
+			aiTextureType_BASE_COLOR,
 			baseDir,
 			m_->cache,
-			m_->white);
+			nullptr);
+		if (!baseColor)
+		{
+			baseColor = LoadTextureFromMaterial(
+				device, scene, mat,
+				aiTextureType_DIFFUSE,
+				baseDir,
+				m_->cache,
+				m_->white);
+		}
+		m_->baseColorSRVs[m] = baseColor;
 
 		// Normal map
 		m_->normalSRVs[m] = LoadTextureFromMaterial(

--- a/Engine/src/Runtime/Rendering/Components/MaterialComponent.h
+++ b/Engine/src/Runtime/Rendering/Components/MaterialComponent.h
@@ -53,6 +53,7 @@ namespace Alice {
         float toonPbrLevel3Alpha{ 1.0f };
         float toonPbrStrength{ 1.0f }; // 0: 부드러운 PBR, 1: 완전 Toon
         bool  toonPbrBlur{ false };    // 계단 사이를 부드럽게 블러 처리
+        float toonPbrRampIntensity{ 0.0f }; // 0: 기존, 1: 가장 어두운 밴드 완화
 
         Alice_Get_Set(color);
         Alice_Get_Set(alpha);
@@ -80,5 +81,6 @@ namespace Alice {
         Alice_Get_Set(toonPbrLevel3Alpha);
         Alice_Get_Set(toonPbrStrength);
         Alice_Get_Set(toonPbrBlur);
+        Alice_Get_Set(toonPbrRampIntensity);
     };
 }

--- a/Engine/src/Runtime/Rendering/Components/MaterialComponent.h
+++ b/Engine/src/Runtime/Rendering/Components/MaterialComponent.h
@@ -54,6 +54,7 @@ namespace Alice {
         float toonPbrStrength{ 1.0f }; // 0: 부드러운 PBR, 1: 완전 Toon
         bool  toonPbrBlur{ false };    // 계단 사이를 부드럽게 블러 처리
         float toonPbrRampIntensity{ 0.0f }; // 0: 기존, 1: 가장 어두운 밴드 완화
+        float toonSelfShadowStrength{ 1.0f }; // 0: 셀프 음영 최소화, 1: 기존 Toon 셀프 음영
 
         Alice_Get_Set(color);
         Alice_Get_Set(alpha);
@@ -82,5 +83,6 @@ namespace Alice {
         Alice_Get_Set(toonPbrStrength);
         Alice_Get_Set(toonPbrBlur);
         Alice_Get_Set(toonPbrRampIntensity);
+        Alice_Get_Set(toonSelfShadowStrength);
     };
 }

--- a/Engine/src/Runtime/Rendering/Components/MaterialComponent.h
+++ b/Engine/src/Runtime/Rendering/Components/MaterialComponent.h
@@ -47,6 +47,9 @@ namespace Alice {
         float toonPbrLevel1{ 0.1f };
         float toonPbrLevel2{ 0.4f };
         float toonPbrLevel3{ 0.7f };
+        float toonPbrLevel1Alpha{ 1.0f };
+        float toonPbrLevel2Alpha{ 1.0f };
+        float toonPbrLevel3Alpha{ 1.0f };
         float toonPbrStrength{ 1.0f }; // 0: 부드러운 PBR, 1: 완전 Toon
         bool  toonPbrBlur{ false };    // 계단 사이를 부드럽게 블러 처리
 
@@ -70,6 +73,9 @@ namespace Alice {
         Alice_Get_Set(toonPbrLevel1);
         Alice_Get_Set(toonPbrLevel2);
         Alice_Get_Set(toonPbrLevel3);
+        Alice_Get_Set(toonPbrLevel1Alpha);
+        Alice_Get_Set(toonPbrLevel2Alpha);
+        Alice_Get_Set(toonPbrLevel3Alpha);
         Alice_Get_Set(toonPbrStrength);
         Alice_Get_Set(toonPbrBlur);
     };

--- a/Engine/src/Runtime/Rendering/Components/MaterialComponent.h
+++ b/Engine/src/Runtime/Rendering/Components/MaterialComponent.h
@@ -24,6 +24,7 @@ namespace Alice {
         float roughness{ 0.5f };                     // 0~1 러프니스 (PBR)
         float metalness{ 0.0f };                     // 0~1 메탈니스 (PBR)
         float ambientOcclusion{ 1.0f };              // 0~1 AO (Ambient Occlusion)
+        float shadowStrength{ 1.0f };                // 0~1 그림자 강도 (0=그림자 없음, 1=기본)
         float envDiffuseStrength{ 1.0f };            // IBL Diffuse 기여도 (0 = 없음)
         float envSpecularStrength{ 1.0f };           // IBL Specular 기여도 (0 = 없음)
         int shadingMode{ -1 };                       // -1: 전역, 0~7: 개별 셰이딩 모드, 6: OnlyTextureWithOutline, 7: ToonPBREditable
@@ -58,6 +59,7 @@ namespace Alice {
         Alice_Get_Set(roughness);
         Alice_Get_Set(metalness);
         Alice_Get_Set(ambientOcclusion);
+        Alice_Get_Set(shadowStrength);
         Alice_Get_Set(envDiffuseStrength);
         Alice_Get_Set(envSpecularStrength);
         Alice_Get_Set(shadingMode);

--- a/Engine/src/Runtime/Rendering/Data/Material.cpp
+++ b/Engine/src/Runtime/Rendering/Data/Material.cpp
@@ -69,6 +69,7 @@ namespace Alice
         outMaterial.toonPbrLevel2Alpha = std::clamp(outMaterial.toonPbrLevel2Alpha, 0.0f, 1.0f);
         outMaterial.toonPbrLevel3Alpha = std::clamp(outMaterial.toonPbrLevel3Alpha, 0.0f, 1.0f);
         outMaterial.toonPbrRampIntensity = std::clamp(outMaterial.toonPbrRampIntensity, 0.0f, 1.0f);
+        outMaterial.toonSelfShadowStrength = std::clamp(outMaterial.toonSelfShadowStrength, 0.0f, 1.0f);
         // 노말맵 강도는 0.0f 이상으로 제한
         outMaterial.normalStrength = std::max(outMaterial.normalStrength, 0.0f);
         // 아웃라인 두께는 음수 방지
@@ -106,6 +107,7 @@ namespace Alice
         copy.toonPbrLevel2Alpha = std::clamp(copy.toonPbrLevel2Alpha, 0.0f, 1.0f);
         copy.toonPbrLevel3Alpha = std::clamp(copy.toonPbrLevel3Alpha, 0.0f, 1.0f);
         copy.toonPbrRampIntensity = std::clamp(copy.toonPbrRampIntensity, 0.0f, 1.0f);
+        copy.toonSelfShadowStrength = std::clamp(copy.toonSelfShadowStrength, 0.0f, 1.0f);
         copy.normalStrength = std::max(copy.normalStrength, 0.0f);
         copy.outlineWidth = std::max(copy.outlineWidth, 0.0f);
 

--- a/Engine/src/Runtime/Rendering/Data/Material.cpp
+++ b/Engine/src/Runtime/Rendering/Data/Material.cpp
@@ -62,6 +62,7 @@ namespace Alice
         outMaterial.roughness = std::clamp(outMaterial.roughness, 0.0f, 1.0f);
         outMaterial.metalness = std::clamp(outMaterial.metalness, 0.0f, 1.0f);
         outMaterial.ambientOcclusion = std::clamp(outMaterial.ambientOcclusion, 0.0f, 1.0f);
+        outMaterial.shadowStrength = std::clamp(outMaterial.shadowStrength, 0.0f, 1.0f);
         outMaterial.envDiffuseStrength = std::max(outMaterial.envDiffuseStrength, 0.0f);
         outMaterial.envSpecularStrength = std::max(outMaterial.envSpecularStrength, 0.0f);
         outMaterial.toonPbrLevel1Alpha = std::clamp(outMaterial.toonPbrLevel1Alpha, 0.0f, 1.0f);
@@ -97,6 +98,7 @@ namespace Alice
         copy.roughness = std::clamp(copy.roughness, 0.0f, 1.0f);
         copy.metalness = std::clamp(copy.metalness, 0.0f, 1.0f);
         copy.ambientOcclusion = std::clamp(copy.ambientOcclusion, 0.0f, 1.0f);
+        copy.shadowStrength = std::clamp(copy.shadowStrength, 0.0f, 1.0f);
         copy.envDiffuseStrength = std::max(copy.envDiffuseStrength, 0.0f);
         copy.envSpecularStrength = std::max(copy.envSpecularStrength, 0.0f);
         copy.toonPbrLevel1Alpha = std::clamp(copy.toonPbrLevel1Alpha, 0.0f, 1.0f);

--- a/Engine/src/Runtime/Rendering/Data/Material.cpp
+++ b/Engine/src/Runtime/Rendering/Data/Material.cpp
@@ -64,6 +64,9 @@ namespace Alice
         outMaterial.ambientOcclusion = std::clamp(outMaterial.ambientOcclusion, 0.0f, 1.0f);
         outMaterial.envDiffuseStrength = std::max(outMaterial.envDiffuseStrength, 0.0f);
         outMaterial.envSpecularStrength = std::max(outMaterial.envSpecularStrength, 0.0f);
+        outMaterial.toonPbrLevel1Alpha = std::clamp(outMaterial.toonPbrLevel1Alpha, 0.0f, 1.0f);
+        outMaterial.toonPbrLevel2Alpha = std::clamp(outMaterial.toonPbrLevel2Alpha, 0.0f, 1.0f);
+        outMaterial.toonPbrLevel3Alpha = std::clamp(outMaterial.toonPbrLevel3Alpha, 0.0f, 1.0f);
         // 노말맵 강도는 0.0f 이상으로 제한
         outMaterial.normalStrength = std::max(outMaterial.normalStrength, 0.0f);
         // 아웃라인 두께는 음수 방지
@@ -96,6 +99,9 @@ namespace Alice
         copy.ambientOcclusion = std::clamp(copy.ambientOcclusion, 0.0f, 1.0f);
         copy.envDiffuseStrength = std::max(copy.envDiffuseStrength, 0.0f);
         copy.envSpecularStrength = std::max(copy.envSpecularStrength, 0.0f);
+        copy.toonPbrLevel1Alpha = std::clamp(copy.toonPbrLevel1Alpha, 0.0f, 1.0f);
+        copy.toonPbrLevel2Alpha = std::clamp(copy.toonPbrLevel2Alpha, 0.0f, 1.0f);
+        copy.toonPbrLevel3Alpha = std::clamp(copy.toonPbrLevel3Alpha, 0.0f, 1.0f);
         copy.normalStrength = std::max(copy.normalStrength, 0.0f);
         copy.outlineWidth = std::max(copy.outlineWidth, 0.0f);
 

--- a/Engine/src/Runtime/Rendering/Data/Material.cpp
+++ b/Engine/src/Runtime/Rendering/Data/Material.cpp
@@ -68,6 +68,7 @@ namespace Alice
         outMaterial.toonPbrLevel1Alpha = std::clamp(outMaterial.toonPbrLevel1Alpha, 0.0f, 1.0f);
         outMaterial.toonPbrLevel2Alpha = std::clamp(outMaterial.toonPbrLevel2Alpha, 0.0f, 1.0f);
         outMaterial.toonPbrLevel3Alpha = std::clamp(outMaterial.toonPbrLevel3Alpha, 0.0f, 1.0f);
+        outMaterial.toonPbrRampIntensity = std::clamp(outMaterial.toonPbrRampIntensity, 0.0f, 1.0f);
         // 노말맵 강도는 0.0f 이상으로 제한
         outMaterial.normalStrength = std::max(outMaterial.normalStrength, 0.0f);
         // 아웃라인 두께는 음수 방지
@@ -104,6 +105,7 @@ namespace Alice
         copy.toonPbrLevel1Alpha = std::clamp(copy.toonPbrLevel1Alpha, 0.0f, 1.0f);
         copy.toonPbrLevel2Alpha = std::clamp(copy.toonPbrLevel2Alpha, 0.0f, 1.0f);
         copy.toonPbrLevel3Alpha = std::clamp(copy.toonPbrLevel3Alpha, 0.0f, 1.0f);
+        copy.toonPbrRampIntensity = std::clamp(copy.toonPbrRampIntensity, 0.0f, 1.0f);
         copy.normalStrength = std::max(copy.normalStrength, 0.0f);
         copy.outlineWidth = std::max(copy.outlineWidth, 0.0f);
 

--- a/Engine/src/Runtime/Rendering/DeferredRenderSystem.cpp
+++ b/Engine/src/Runtime/Rendering/DeferredRenderSystem.cpp
@@ -82,6 +82,7 @@ namespace Alice
             DirectX::XMFLOAT4 toonPbrLevels { 0.1f, 0.4f, 0.7f, 0.0f };
             DirectX::XMFLOAT4 toonPbrAlphas { 1.0f, 1.0f, 1.0f, 0.0f };
             float toonPbrRampIntensity = 0.0f;
+            float toonSelfShadowStrength = 1.0f;
             int shadingMode = 0;
             int useTexture = 0;
             int enableNormalMap = 0;
@@ -121,6 +122,7 @@ namespace Alice
                 if (toonPbrAlphas.z != rhs.toonPbrAlphas.z) return toonPbrAlphas.z < rhs.toonPbrAlphas.z;
                 if (toonPbrAlphas.w != rhs.toonPbrAlphas.w) return toonPbrAlphas.w < rhs.toonPbrAlphas.w;
                 if (toonPbrRampIntensity != rhs.toonPbrRampIntensity) return toonPbrRampIntensity < rhs.toonPbrRampIntensity;
+                if (toonSelfShadowStrength != rhs.toonSelfShadowStrength) return toonSelfShadowStrength < rhs.toonSelfShadowStrength;
                 if (shadingMode != rhs.shadingMode) return shadingMode < rhs.shadingMode;
                 if (useTexture != rhs.useTexture) return useTexture < rhs.useTexture;
                 if (enableNormalMap != rhs.enableNormalMap) return enableNormalMap < rhs.enableNormalMap;
@@ -162,6 +164,7 @@ namespace Alice
             if (a.toonPbrAlphas.z != b.toonPbrAlphas.z) return false;
             if (a.toonPbrAlphas.w != b.toonPbrAlphas.w) return false;
             if (a.toonPbrRampIntensity != b.toonPbrRampIntensity) return false;
+            if (a.toonSelfShadowStrength != b.toonSelfShadowStrength) return false;
             if (a.shadingMode != b.shadingMode) return false;
             if (a.useTexture != b.useTexture) return false;
             if (a.enableNormalMap != b.enableNormalMap) return false;
@@ -2125,7 +2128,7 @@ namespace Alice
 
                 UpdatePerObjectCB(worldM, lightView, lightProj, XMFLOAT4(1, 1, 1, 1), 1.0f, 0.0f, 1.0f, false, false, 0,
                                   1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(), DefaultToonPbrAlphas(),
-                                  0.0f, 1.0f, 1.0f,
+                                  0.0f, 1.0f, 1.0f, 1.0f,
                                   XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
                 m_context->DrawIndexed(m_cubeIndexCount, 0, 0);
             }
@@ -2172,7 +2175,7 @@ namespace Alice
 
                                 UpdatePerObjectCB(DirectX::XMMatrixIdentity(), lightView, lightProj, XMFLOAT4(1, 1, 1, 1), 1.0f, 0.0f, 1.0f, false, false, 0,
                                                   1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(), DefaultToonPbrAlphas(),
-                                                  0.0f, 1.0f, 1.0f,
+                                                  0.0f, 1.0f, 1.0f, 1.0f,
                                                   XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
                                 m_context->DrawIndexedInstanced(currentKey.indexCount, (UINT)batchInstances.size(),
                                                                 currentKey.startIndex, currentKey.baseVertex, 0);
@@ -2205,7 +2208,7 @@ namespace Alice
 
                         UpdatePerObjectCB(DirectX::XMMatrixIdentity(), lightView, lightProj, XMFLOAT4(1, 1, 1, 1), 1.0f, 0.0f, 1.0f, false, false, 0,
                                           1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(), DefaultToonPbrAlphas(),
-                                          0.0f, 1.0f, 1.0f,
+                                          0.0f, 1.0f, 1.0f, 1.0f,
                                           XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
                         m_context->DrawIndexedInstanced(currentKey.indexCount, (UINT)batchInstances.size(),
                                                         currentKey.startIndex, currentKey.baseVertex, 0);
@@ -2316,7 +2319,7 @@ namespace Alice
                 UpdateBonesCB(cmd.bones, cmd.boneCount);
                 UpdatePerObjectCB(cmd.world, lightView, lightProj, XMFLOAT4(1, 1, 1, 1), 1.0f, 0.0f, 1.0f, false, false, 0,
                                   1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(), DefaultToonPbrAlphas(),
-                                  0.0f, 1.0f, 1.0f, XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
+                                  0.0f, 1.0f, 1.0f, 1.0f, XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
                 m_context->DrawIndexed(cmd.indexCount, cmd.startIndex, cmd.baseVertex);
             }
 
@@ -2367,7 +2370,7 @@ namespace Alice
                                 // CB는 배치 단위로 1회만 갱신
                                 UpdatePerObjectCB(DirectX::XMMatrixIdentity(), lightView, lightProj, XMFLOAT4(1, 1, 1, 1), 1.0f, 0.0f, 1.0f, false, false, 0,
                                                   1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(), DefaultToonPbrAlphas(),
-                                                  0.0f, 1.0f, 1.0f,
+                                                  0.0f, 1.0f, 1.0f, 1.0f,
                                                   XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
 
                                 m_context->DrawIndexedInstanced(currentKey.indexCount, (UINT)batchInstances.size(), currentKey.startIndex, currentKey.baseVertex, 0);
@@ -2401,7 +2404,7 @@ namespace Alice
 
                         UpdatePerObjectCB(DirectX::XMMatrixIdentity(), lightView, lightProj, XMFLOAT4(1, 1, 1, 1), 1.0f, 0.0f, 1.0f, false, false, 0,
                                           1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(), DefaultToonPbrAlphas(),
-                                          0.0f, 1.0f, 1.0f, XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
+                                          0.0f, 1.0f, 1.0f, 1.0f, XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
 
                         m_context->DrawIndexedInstanced(currentKey.indexCount, (UINT)batchInstances.size(), currentKey.startIndex, currentKey.baseVertex, 0);
                     }
@@ -2945,6 +2948,7 @@ namespace Alice
             XMFLOAT4 toonLevels = DefaultToonPbrLevels();
             XMFLOAT4 toonAlphas = DefaultToonPbrAlphas();
             float toonRampIntensity = 0.0f;
+            float toonSelfShadowStrength = 1.0f;
             int objectShadingMode = shadingMode;
             if (mat) {
                 color = { mat->color.x, mat->color.y, mat->color.z, mat->alpha };
@@ -2962,6 +2966,7 @@ namespace Alice
                     mat->toonPbrBlur ? 1.0f : 0.0f);
                 toonAlphas = XMFLOAT4(mat->toonPbrLevel1Alpha, mat->toonPbrLevel2Alpha, mat->toonPbrLevel3Alpha, mat->shadowStrength);
                 toonRampIntensity = mat->toonPbrRampIntensity;
+                toonSelfShadowStrength = mat->toonSelfShadowStrength;
                 if (mat->shadingMode >= 0) objectShadingMode = mat->shadingMode;
                 if (!mat->albedoTexturePath.empty()) {
                     texSRV = GetOrCreateTexture(mat->albedoTexturePath);
@@ -2996,6 +3001,7 @@ namespace Alice
                 item.key.toonPbrLevels = toonLevels;
                 item.key.toonPbrAlphas = toonAlphas;
                 item.key.toonPbrRampIntensity = toonRampIntensity;
+                item.key.toonSelfShadowStrength = toonSelfShadowStrength;
                 item.key.shadingMode = objectShadingMode;
                 item.key.useTexture = useTex ? 1 : 0;
                 item.key.enableNormalMap = 0;
@@ -3011,7 +3017,7 @@ namespace Alice
 
             // Pass 1. 원본 물체 그리기 (아웃라인 두께 0으로 강제)
             UpdatePerObjectCB(worldM, view, proj, color, rough, metal, ao, useTex, false,
-                              objectShadingMode, normalStrength, toonCuts, toonLevels, toonAlphas, toonRampIntensity,
+                              objectShadingMode, normalStrength, toonCuts, toonLevels, toonAlphas, toonRampIntensity, toonSelfShadowStrength,
                               envDiffuseStrength, envSpecularStrength,
                               outlineColor, 0.0f); // width = 0
             m_context->DrawIndexed(m_cubeIndexCount, 0, 0);
@@ -3023,7 +3029,7 @@ namespace Alice
                 
                 // 아웃라인 값 적용
                 UpdatePerObjectCB(worldM, view, proj, color, rough, metal, ao, useTex, false,
-                                  objectShadingMode, normalStrength, toonCuts, toonLevels, toonAlphas, toonRampIntensity,
+                                  objectShadingMode, normalStrength, toonCuts, toonLevels, toonAlphas, toonRampIntensity, toonSelfShadowStrength,
                                   envDiffuseStrength, envSpecularStrength,
                                   outlineColor, outlineWidth);
                 m_context->DrawIndexed(m_cubeIndexCount, 0, 0);
@@ -3075,7 +3081,7 @@ namespace Alice
                                               currentKey.roughness, currentKey.metalness, currentKey.ambientOcclusion,
                                               (currentKey.useTexture != 0), (currentKey.enableNormalMap != 0),
                                               currentKey.shadingMode, currentKey.normalStrength,
-                                              currentKey.toonPbrCuts, currentKey.toonPbrLevels, currentKey.toonPbrAlphas, currentKey.toonPbrRampIntensity,
+                                              currentKey.toonPbrCuts, currentKey.toonPbrLevels, currentKey.toonPbrAlphas, currentKey.toonPbrRampIntensity, currentKey.toonSelfShadowStrength,
                                               currentKey.envDiffuseStrength, currentKey.envSpecularStrength,
                                               DirectX::XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
 
@@ -3112,7 +3118,7 @@ namespace Alice
                                       currentKey.roughness, currentKey.metalness, currentKey.ambientOcclusion,
                                       (currentKey.useTexture != 0), (currentKey.enableNormalMap != 0),
                                       currentKey.shadingMode, currentKey.normalStrength,
-                                      currentKey.toonPbrCuts, currentKey.toonPbrLevels, currentKey.toonPbrAlphas, currentKey.toonPbrRampIntensity,
+                                      currentKey.toonPbrCuts, currentKey.toonPbrLevels, currentKey.toonPbrAlphas, currentKey.toonPbrRampIntensity, currentKey.toonSelfShadowStrength,
                                       currentKey.envDiffuseStrength, currentKey.envSpecularStrength,
                                       DirectX::XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
 
@@ -3215,6 +3221,7 @@ namespace Alice
                             item.key.toonPbrLevels = cmd.toonPbrLevels;
                             item.key.toonPbrAlphas = cmd.toonPbrAlphas;
                             item.key.toonPbrRampIntensity = cmd.toonPbrRampIntensity;
+                            item.key.toonSelfShadowStrength = cmd.toonSelfShadowStrength;
                             item.key.shadingMode = objectShadingMode;
                             item.key.useTexture = (diff != nullptr) ? 1 : 0;
                             item.key.enableNormalMap = (norm != nullptr) ? 1 : 0;
@@ -3248,6 +3255,7 @@ namespace Alice
                         item.key.toonPbrLevels = cmd.toonPbrLevels;
                         item.key.toonPbrAlphas = cmd.toonPbrAlphas;
                         item.key.toonPbrRampIntensity = cmd.toonPbrRampIntensity;
+                        item.key.toonSelfShadowStrength = cmd.toonSelfShadowStrength;
                         item.key.shadingMode = objectShadingMode;
                         item.key.useTexture = (diff != nullptr) ? 1 : 0;
                         item.key.enableNormalMap = 0;
@@ -3283,7 +3291,7 @@ namespace Alice
                         // Pass 1. 원본
                         UpdatePerObjectCB(cmd.world, view, proj, color, cmd.roughness, cmd.metalness, ao,
                                           (diff != nullptr), (norm != nullptr), objectShadingMode, 
-                                          cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas, cmd.toonPbrRampIntensity,
+                                          cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas, cmd.toonPbrRampIntensity, cmd.toonSelfShadowStrength,
                                           cmd.envDiffuseStrength, cmd.envSpecularStrength,
                                           cmd.outlineColor, 0.0f); // width 0
                         m_context->DrawIndexed(sub.indexCount, sub.startIndex, cmd.baseVertex);
@@ -3294,7 +3302,7 @@ namespace Alice
                             m_context->RSSetState(m_rsCullFront.Get());
                             UpdatePerObjectCB(cmd.world, view, proj, color, cmd.roughness, cmd.metalness, ao,
                                               (diff != nullptr), (norm != nullptr), objectShadingMode, 
-                                              cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas, cmd.toonPbrRampIntensity,
+                                              cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas, cmd.toonPbrRampIntensity, cmd.toonSelfShadowStrength,
                                               cmd.envDiffuseStrength, cmd.envSpecularStrength,
                                               cmd.outlineColor, cmd.outlineWidth);
                             m_context->DrawIndexed(sub.indexCount, sub.startIndex, cmd.baseVertex);
@@ -3312,7 +3320,7 @@ namespace Alice
                     // Pass 1. 원본
                     UpdatePerObjectCB(cmd.world, view, proj, color, cmd.roughness, cmd.metalness, ao,
                                       (diff != nullptr), false, objectShadingMode, 
-                                      cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas, cmd.toonPbrRampIntensity,
+                                      cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas, cmd.toonPbrRampIntensity, cmd.toonSelfShadowStrength,
                                       cmd.envDiffuseStrength, cmd.envSpecularStrength,
                                       cmd.outlineColor, 0.0f);
                     m_context->DrawIndexed(cmd.indexCount, cmd.startIndex, cmd.baseVertex);
@@ -3323,7 +3331,7 @@ namespace Alice
                         m_context->RSSetState(m_rsCullFront.Get());
                         UpdatePerObjectCB(cmd.world, view, proj, color, cmd.roughness, cmd.metalness, ao,
                                           (diff != nullptr), false, objectShadingMode, 
-                                          cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas, cmd.toonPbrRampIntensity,
+                                          cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas, cmd.toonPbrRampIntensity, cmd.toonSelfShadowStrength,
                                           cmd.envDiffuseStrength, cmd.envSpecularStrength,
                                           cmd.outlineColor, cmd.outlineWidth);
                         m_context->DrawIndexed(cmd.indexCount, cmd.startIndex, cmd.baseVertex);
@@ -3374,7 +3382,7 @@ namespace Alice
                                                   currentKey.roughness, currentKey.metalness, currentKey.ambientOcclusion,
                                                   (currentKey.useTexture != 0), (currentKey.enableNormalMap != 0),
                                                   currentKey.shadingMode, currentKey.normalStrength,
-                                                  currentKey.toonPbrCuts, currentKey.toonPbrLevels, currentKey.toonPbrAlphas, currentKey.toonPbrRampIntensity,
+                                                  currentKey.toonPbrCuts, currentKey.toonPbrLevels, currentKey.toonPbrAlphas, currentKey.toonPbrRampIntensity, currentKey.toonSelfShadowStrength,
                                                   currentKey.envDiffuseStrength, currentKey.envSpecularStrength,
                                                   DirectX::XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
 
@@ -3411,7 +3419,7 @@ namespace Alice
                                           currentKey.roughness, currentKey.metalness, currentKey.ambientOcclusion,
                                           (currentKey.useTexture != 0), (currentKey.enableNormalMap != 0),
                                           currentKey.shadingMode, currentKey.normalStrength,
-                                          currentKey.toonPbrCuts, currentKey.toonPbrLevels, currentKey.toonPbrAlphas, currentKey.toonPbrRampIntensity,
+                                          currentKey.toonPbrCuts, currentKey.toonPbrLevels, currentKey.toonPbrAlphas, currentKey.toonPbrRampIntensity, currentKey.toonSelfShadowStrength,
                                           currentKey.envDiffuseStrength, currentKey.envSpecularStrength,
                                           DirectX::XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
 
@@ -3520,7 +3528,7 @@ namespace Alice
                                               0.5f, 0.0f, m_lightingParameters.ambientOcclusion,
                                               (diff != nullptr), (norm != nullptr),
                                               shadingMode,
-                                              1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(), DefaultToonPbrAlphas(), 0.0f,
+                                              1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(), DefaultToonPbrAlphas(), 0.0f, 1.0f,
                                               1.0f, 1.0f,
                                               DirectX::XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
 
@@ -3535,7 +3543,7 @@ namespace Alice
                         UpdatePerObjectCB(cameraIconWorld, view, proj, cameraColor,
                                           0.5f, 0.0f, m_lightingParameters.ambientOcclusion,
                                           false, false, shadingMode,
-                                          1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(), DefaultToonPbrAlphas(), 0.0f,
+                                          1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(), DefaultToonPbrAlphas(), 0.0f, 1.0f,
                                           1.0f, 1.0f,
                                           DirectX::XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
 
@@ -3959,6 +3967,7 @@ namespace Alice
                 key.toonPbrLevels = cmd.toonPbrLevels;
                 key.toonPbrAlphas = cmd.toonPbrAlphas;
                 key.toonPbrRampIntensity = cmd.toonPbrRampIntensity;
+                key.toonSelfShadowStrength = cmd.toonSelfShadowStrength;
                 key.shadingMode = objectShadingMode;
                 key.useTexture = (diff != nullptr) ? 1 : 0;
                 key.enableNormalMap = (norm != nullptr) ? 1 : 0;
@@ -3991,7 +4000,7 @@ namespace Alice
                                           batchKey.roughness, batchKey.metalness, batchKey.ambientOcclusion,
                                           (batchKey.useTexture != 0), (batchKey.enableNormalMap != 0),
                                           batchKey.shadingMode, batchKey.normalStrength,
-                                          batchKey.toonPbrCuts, batchKey.toonPbrLevels, batchKey.toonPbrAlphas, batchKey.toonPbrRampIntensity,
+                                          batchKey.toonPbrCuts, batchKey.toonPbrLevels, batchKey.toonPbrAlphas, batchKey.toonPbrRampIntensity, batchKey.toonSelfShadowStrength,
                                           batchKey.envDiffuseStrength, batchKey.envSpecularStrength,
                                           DirectX::XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
 
@@ -4045,7 +4054,7 @@ namespace Alice
                                       batchKey.roughness, batchKey.metalness, batchKey.ambientOcclusion,
                                       (batchKey.useTexture != 0), (batchKey.enableNormalMap != 0),
                                       batchKey.shadingMode, batchKey.normalStrength,
-                                      batchKey.toonPbrCuts, batchKey.toonPbrLevels, batchKey.toonPbrAlphas, batchKey.toonPbrRampIntensity,
+                                      batchKey.toonPbrCuts, batchKey.toonPbrLevels, batchKey.toonPbrAlphas, batchKey.toonPbrRampIntensity, batchKey.toonSelfShadowStrength,
                                       batchKey.envDiffuseStrength, batchKey.envSpecularStrength,
                                       DirectX::XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
 
@@ -4088,7 +4097,7 @@ namespace Alice
                     // Pass 1. 원본
                     UpdatePerObjectCB(cmd.world, view, proj, color, cmd.roughness, cmd.metalness, ao,
                                       (diff != nullptr), (norm != nullptr), objectShadingMode,
-                                      cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas, cmd.toonPbrRampIntensity,
+                                      cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas, cmd.toonPbrRampIntensity, cmd.toonSelfShadowStrength,
                                       cmd.envDiffuseStrength, cmd.envSpecularStrength,
                                       outlineColor, 0.0f);
                     m_context->DrawIndexed(sub.indexCount, sub.startIndex, cmd.baseVertex);
@@ -4099,7 +4108,7 @@ namespace Alice
                         m_context->RSSetState(m_rsCullFront.Get());
                         UpdatePerObjectCB(cmd.world, view, proj, color, cmd.roughness, cmd.metalness, ao,
                                           (diff != nullptr), (norm != nullptr), objectShadingMode,
-                                          cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas, cmd.toonPbrRampIntensity,
+                                          cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas, cmd.toonPbrRampIntensity, cmd.toonSelfShadowStrength,
                                           cmd.envDiffuseStrength, cmd.envSpecularStrength,
                                           outlineColor, outlineWidth);
                         m_context->DrawIndexed(sub.indexCount, sub.startIndex, cmd.baseVertex);
@@ -4116,7 +4125,7 @@ namespace Alice
                 // [Pass 1] 원본
                 UpdatePerObjectCB(cmd.world, view, proj, color, cmd.roughness, cmd.metalness, ao,
                                   (diff != nullptr), false, objectShadingMode,
-                                  cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas, cmd.toonPbrRampIntensity,
+                                  cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas, cmd.toonPbrRampIntensity, cmd.toonSelfShadowStrength,
                                   cmd.envDiffuseStrength, cmd.envSpecularStrength,
                                   outlineColor, 0.0f);
                 m_context->DrawIndexed(cmd.indexCount, cmd.startIndex, cmd.baseVertex);
@@ -4127,7 +4136,7 @@ namespace Alice
                     m_context->RSSetState(m_rsCullFront.Get());
                     UpdatePerObjectCB(cmd.world, view, proj, color, cmd.roughness, cmd.metalness, ao,
                                       (diff != nullptr), false, objectShadingMode,
-                                      cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas, cmd.toonPbrRampIntensity,
+                                      cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas, cmd.toonPbrRampIntensity, cmd.toonSelfShadowStrength,
                                       cmd.envDiffuseStrength, cmd.envSpecularStrength,
                                       outlineColor, outlineWidth);
                     m_context->DrawIndexed(cmd.indexCount, cmd.startIndex, cmd.baseVertex);
@@ -4164,7 +4173,7 @@ namespace Alice
                                   batchKey.roughness, batchKey.metalness, batchKey.ambientOcclusion,
                                   (batchKey.useTexture != 0), (batchKey.enableNormalMap != 0),
                                   batchKey.shadingMode, batchKey.normalStrength,
-                                  batchKey.toonPbrCuts, batchKey.toonPbrLevels, batchKey.toonPbrAlphas, batchKey.toonPbrRampIntensity,
+                                  batchKey.toonPbrCuts, batchKey.toonPbrLevels, batchKey.toonPbrAlphas, batchKey.toonPbrRampIntensity, batchKey.toonSelfShadowStrength,
                                   batchKey.envDiffuseStrength, batchKey.envSpecularStrength,
                                   DirectX::XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
 
@@ -4288,6 +4297,7 @@ namespace Alice
                                                  const DirectX::XMFLOAT4& toonPbrLevels,
                                                  const DirectX::XMFLOAT4& toonPbrAlphas,
                                                  float toonPbrRampIntensity,
+                                                 float toonSelfShadowStrength,
                                                  float envDiffuseStrength,
                                                  float envSpecularStrength,
                                                  const XMFLOAT3& outlineColor,
@@ -4316,8 +4326,9 @@ namespace Alice
             XMFLOAT4 gToonPbrLevels;  // Offset: 272 -> 288
             XMFLOAT4 gToonPbrAlphas;  // Offset: 288 -> 304
             float    gToonPbrRampIntensity; // Offset: 304 -> 308
-            XMFLOAT3 gOutlineColor;   // Offset: 308 -> 320
-            float    gOutlineWidth;   // Offset: 320 -> 324
+            float    gToonSelfShadowStrength; // Offset: 308 -> 312
+            XMFLOAT3 gOutlineColor;   // Offset: 312 -> 324
+            float    gOutlineWidth;   // Offset: 324 -> 328
         };
 
         D3D11_MAPPED_SUBRESOURCE mapped;
@@ -4345,6 +4356,7 @@ namespace Alice
             data->gToonPbrLevels = toonPbrLevels;
             data->gToonPbrAlphas = toonPbrAlphas;
             data->gToonPbrRampIntensity = toonPbrRampIntensity;
+            data->gToonSelfShadowStrength = toonSelfShadowStrength;
             data->gOutlineColor = outlineColor;
             data->gOutlineWidth = outlineWidth;
             m_context->Unmap(m_cbPerObject.Get(), 0);

--- a/Engine/src/Runtime/Rendering/DeferredRenderSystem.cpp
+++ b/Engine/src/Runtime/Rendering/DeferredRenderSystem.cpp
@@ -81,6 +81,7 @@ namespace Alice
             DirectX::XMFLOAT4 toonPbrCuts { 0.2f, 0.5f, 0.95f, 1.0f };
             DirectX::XMFLOAT4 toonPbrLevels { 0.1f, 0.4f, 0.7f, 0.0f };
             DirectX::XMFLOAT4 toonPbrAlphas { 1.0f, 1.0f, 1.0f, 0.0f };
+            float toonPbrRampIntensity = 0.0f;
             int shadingMode = 0;
             int useTexture = 0;
             int enableNormalMap = 0;
@@ -119,6 +120,7 @@ namespace Alice
                 if (toonPbrAlphas.y != rhs.toonPbrAlphas.y) return toonPbrAlphas.y < rhs.toonPbrAlphas.y;
                 if (toonPbrAlphas.z != rhs.toonPbrAlphas.z) return toonPbrAlphas.z < rhs.toonPbrAlphas.z;
                 if (toonPbrAlphas.w != rhs.toonPbrAlphas.w) return toonPbrAlphas.w < rhs.toonPbrAlphas.w;
+                if (toonPbrRampIntensity != rhs.toonPbrRampIntensity) return toonPbrRampIntensity < rhs.toonPbrRampIntensity;
                 if (shadingMode != rhs.shadingMode) return shadingMode < rhs.shadingMode;
                 if (useTexture != rhs.useTexture) return useTexture < rhs.useTexture;
                 if (enableNormalMap != rhs.enableNormalMap) return enableNormalMap < rhs.enableNormalMap;
@@ -159,6 +161,7 @@ namespace Alice
             if (a.toonPbrAlphas.y != b.toonPbrAlphas.y) return false;
             if (a.toonPbrAlphas.z != b.toonPbrAlphas.z) return false;
             if (a.toonPbrAlphas.w != b.toonPbrAlphas.w) return false;
+            if (a.toonPbrRampIntensity != b.toonPbrRampIntensity) return false;
             if (a.shadingMode != b.shadingMode) return false;
             if (a.useTexture != b.useTexture) return false;
             if (a.enableNormalMap != b.enableNormalMap) return false;
@@ -2122,7 +2125,7 @@ namespace Alice
 
                 UpdatePerObjectCB(worldM, lightView, lightProj, XMFLOAT4(1, 1, 1, 1), 1.0f, 0.0f, 1.0f, false, false, 0,
                                   1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(), DefaultToonPbrAlphas(),
-                                  1.0f, 1.0f,
+                                  0.0f, 1.0f, 1.0f,
                                   XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
                 m_context->DrawIndexed(m_cubeIndexCount, 0, 0);
             }
@@ -2169,7 +2172,7 @@ namespace Alice
 
                                 UpdatePerObjectCB(DirectX::XMMatrixIdentity(), lightView, lightProj, XMFLOAT4(1, 1, 1, 1), 1.0f, 0.0f, 1.0f, false, false, 0,
                                                   1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(), DefaultToonPbrAlphas(),
-                                                  1.0f, 1.0f,
+                                                  0.0f, 1.0f, 1.0f,
                                                   XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
                                 m_context->DrawIndexedInstanced(currentKey.indexCount, (UINT)batchInstances.size(),
                                                                 currentKey.startIndex, currentKey.baseVertex, 0);
@@ -2202,7 +2205,7 @@ namespace Alice
 
                         UpdatePerObjectCB(DirectX::XMMatrixIdentity(), lightView, lightProj, XMFLOAT4(1, 1, 1, 1), 1.0f, 0.0f, 1.0f, false, false, 0,
                                           1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(), DefaultToonPbrAlphas(),
-                                          1.0f, 1.0f,
+                                          0.0f, 1.0f, 1.0f,
                                           XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
                         m_context->DrawIndexedInstanced(currentKey.indexCount, (UINT)batchInstances.size(),
                                                         currentKey.startIndex, currentKey.baseVertex, 0);
@@ -2313,7 +2316,7 @@ namespace Alice
                 UpdateBonesCB(cmd.bones, cmd.boneCount);
                 UpdatePerObjectCB(cmd.world, lightView, lightProj, XMFLOAT4(1, 1, 1, 1), 1.0f, 0.0f, 1.0f, false, false, 0,
                                   1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(), DefaultToonPbrAlphas(),
-                                  1.0f, 1.0f, XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
+                                  0.0f, 1.0f, 1.0f, XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
                 m_context->DrawIndexed(cmd.indexCount, cmd.startIndex, cmd.baseVertex);
             }
 
@@ -2364,7 +2367,7 @@ namespace Alice
                                 // CB는 배치 단위로 1회만 갱신
                                 UpdatePerObjectCB(DirectX::XMMatrixIdentity(), lightView, lightProj, XMFLOAT4(1, 1, 1, 1), 1.0f, 0.0f, 1.0f, false, false, 0,
                                                   1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(), DefaultToonPbrAlphas(),
-                                                  1.0f, 1.0f,
+                                                  0.0f, 1.0f, 1.0f,
                                                   XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
 
                                 m_context->DrawIndexedInstanced(currentKey.indexCount, (UINT)batchInstances.size(), currentKey.startIndex, currentKey.baseVertex, 0);
@@ -2398,7 +2401,7 @@ namespace Alice
 
                         UpdatePerObjectCB(DirectX::XMMatrixIdentity(), lightView, lightProj, XMFLOAT4(1, 1, 1, 1), 1.0f, 0.0f, 1.0f, false, false, 0,
                                           1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(), DefaultToonPbrAlphas(),
-                                          1.0f, 1.0f, XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
+                                          0.0f, 1.0f, 1.0f, XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
 
                         m_context->DrawIndexedInstanced(currentKey.indexCount, (UINT)batchInstances.size(), currentKey.startIndex, currentKey.baseVertex, 0);
                     }
@@ -2941,6 +2944,7 @@ namespace Alice
             XMFLOAT4 toonCuts = DefaultToonPbrCuts();
             XMFLOAT4 toonLevels = DefaultToonPbrLevels();
             XMFLOAT4 toonAlphas = DefaultToonPbrAlphas();
+            float toonRampIntensity = 0.0f;
             int objectShadingMode = shadingMode;
             if (mat) {
                 color = { mat->color.x, mat->color.y, mat->color.z, mat->alpha };
@@ -2957,6 +2961,7 @@ namespace Alice
                 toonLevels = XMFLOAT4(mat->toonPbrLevel1, mat->toonPbrLevel2, mat->toonPbrLevel3,
                     mat->toonPbrBlur ? 1.0f : 0.0f);
                 toonAlphas = XMFLOAT4(mat->toonPbrLevel1Alpha, mat->toonPbrLevel2Alpha, mat->toonPbrLevel3Alpha, mat->shadowStrength);
+                toonRampIntensity = mat->toonPbrRampIntensity;
                 if (mat->shadingMode >= 0) objectShadingMode = mat->shadingMode;
                 if (!mat->albedoTexturePath.empty()) {
                     texSRV = GetOrCreateTexture(mat->albedoTexturePath);
@@ -2990,6 +2995,7 @@ namespace Alice
                 item.key.toonPbrCuts = toonCuts;
                 item.key.toonPbrLevels = toonLevels;
                 item.key.toonPbrAlphas = toonAlphas;
+                item.key.toonPbrRampIntensity = toonRampIntensity;
                 item.key.shadingMode = objectShadingMode;
                 item.key.useTexture = useTex ? 1 : 0;
                 item.key.enableNormalMap = 0;
@@ -3005,7 +3011,7 @@ namespace Alice
 
             // Pass 1. 원본 물체 그리기 (아웃라인 두께 0으로 강제)
             UpdatePerObjectCB(worldM, view, proj, color, rough, metal, ao, useTex, false,
-                              objectShadingMode, normalStrength, toonCuts, toonLevels, toonAlphas,
+                              objectShadingMode, normalStrength, toonCuts, toonLevels, toonAlphas, toonRampIntensity,
                               envDiffuseStrength, envSpecularStrength,
                               outlineColor, 0.0f); // width = 0
             m_context->DrawIndexed(m_cubeIndexCount, 0, 0);
@@ -3017,7 +3023,7 @@ namespace Alice
                 
                 // 아웃라인 값 적용
                 UpdatePerObjectCB(worldM, view, proj, color, rough, metal, ao, useTex, false,
-                                  objectShadingMode, normalStrength, toonCuts, toonLevels, toonAlphas,
+                                  objectShadingMode, normalStrength, toonCuts, toonLevels, toonAlphas, toonRampIntensity,
                                   envDiffuseStrength, envSpecularStrength,
                                   outlineColor, outlineWidth);
                 m_context->DrawIndexed(m_cubeIndexCount, 0, 0);
@@ -3069,7 +3075,7 @@ namespace Alice
                                               currentKey.roughness, currentKey.metalness, currentKey.ambientOcclusion,
                                               (currentKey.useTexture != 0), (currentKey.enableNormalMap != 0),
                                               currentKey.shadingMode, currentKey.normalStrength,
-                                              currentKey.toonPbrCuts, currentKey.toonPbrLevels, currentKey.toonPbrAlphas,
+                                              currentKey.toonPbrCuts, currentKey.toonPbrLevels, currentKey.toonPbrAlphas, currentKey.toonPbrRampIntensity,
                                               currentKey.envDiffuseStrength, currentKey.envSpecularStrength,
                                               DirectX::XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
 
@@ -3106,7 +3112,7 @@ namespace Alice
                                       currentKey.roughness, currentKey.metalness, currentKey.ambientOcclusion,
                                       (currentKey.useTexture != 0), (currentKey.enableNormalMap != 0),
                                       currentKey.shadingMode, currentKey.normalStrength,
-                                      currentKey.toonPbrCuts, currentKey.toonPbrLevels, currentKey.toonPbrAlphas,
+                                      currentKey.toonPbrCuts, currentKey.toonPbrLevels, currentKey.toonPbrAlphas, currentKey.toonPbrRampIntensity,
                                       currentKey.envDiffuseStrength, currentKey.envSpecularStrength,
                                       DirectX::XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
 
@@ -3208,6 +3214,7 @@ namespace Alice
                             item.key.toonPbrCuts = cmd.toonPbrCuts;
                             item.key.toonPbrLevels = cmd.toonPbrLevels;
                             item.key.toonPbrAlphas = cmd.toonPbrAlphas;
+                            item.key.toonPbrRampIntensity = cmd.toonPbrRampIntensity;
                             item.key.shadingMode = objectShadingMode;
                             item.key.useTexture = (diff != nullptr) ? 1 : 0;
                             item.key.enableNormalMap = (norm != nullptr) ? 1 : 0;
@@ -3240,6 +3247,7 @@ namespace Alice
                         item.key.toonPbrCuts = cmd.toonPbrCuts;
                         item.key.toonPbrLevels = cmd.toonPbrLevels;
                         item.key.toonPbrAlphas = cmd.toonPbrAlphas;
+                        item.key.toonPbrRampIntensity = cmd.toonPbrRampIntensity;
                         item.key.shadingMode = objectShadingMode;
                         item.key.useTexture = (diff != nullptr) ? 1 : 0;
                         item.key.enableNormalMap = 0;
@@ -3275,7 +3283,7 @@ namespace Alice
                         // Pass 1. 원본
                         UpdatePerObjectCB(cmd.world, view, proj, color, cmd.roughness, cmd.metalness, ao,
                                           (diff != nullptr), (norm != nullptr), objectShadingMode, 
-                                          cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas,
+                                          cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas, cmd.toonPbrRampIntensity,
                                           cmd.envDiffuseStrength, cmd.envSpecularStrength,
                                           cmd.outlineColor, 0.0f); // width 0
                         m_context->DrawIndexed(sub.indexCount, sub.startIndex, cmd.baseVertex);
@@ -3286,7 +3294,7 @@ namespace Alice
                             m_context->RSSetState(m_rsCullFront.Get());
                             UpdatePerObjectCB(cmd.world, view, proj, color, cmd.roughness, cmd.metalness, ao,
                                               (diff != nullptr), (norm != nullptr), objectShadingMode, 
-                                              cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas,
+                                              cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas, cmd.toonPbrRampIntensity,
                                               cmd.envDiffuseStrength, cmd.envSpecularStrength,
                                               cmd.outlineColor, cmd.outlineWidth);
                             m_context->DrawIndexed(sub.indexCount, sub.startIndex, cmd.baseVertex);
@@ -3304,7 +3312,7 @@ namespace Alice
                     // Pass 1. 원본
                     UpdatePerObjectCB(cmd.world, view, proj, color, cmd.roughness, cmd.metalness, ao,
                                       (diff != nullptr), false, objectShadingMode, 
-                                      cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas,
+                                      cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas, cmd.toonPbrRampIntensity,
                                       cmd.envDiffuseStrength, cmd.envSpecularStrength,
                                       cmd.outlineColor, 0.0f);
                     m_context->DrawIndexed(cmd.indexCount, cmd.startIndex, cmd.baseVertex);
@@ -3315,7 +3323,7 @@ namespace Alice
                         m_context->RSSetState(m_rsCullFront.Get());
                         UpdatePerObjectCB(cmd.world, view, proj, color, cmd.roughness, cmd.metalness, ao,
                                           (diff != nullptr), false, objectShadingMode, 
-                                          cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas,
+                                          cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas, cmd.toonPbrRampIntensity,
                                           cmd.envDiffuseStrength, cmd.envSpecularStrength,
                                           cmd.outlineColor, cmd.outlineWidth);
                         m_context->DrawIndexed(cmd.indexCount, cmd.startIndex, cmd.baseVertex);
@@ -3366,7 +3374,7 @@ namespace Alice
                                                   currentKey.roughness, currentKey.metalness, currentKey.ambientOcclusion,
                                                   (currentKey.useTexture != 0), (currentKey.enableNormalMap != 0),
                                                   currentKey.shadingMode, currentKey.normalStrength,
-                                                  currentKey.toonPbrCuts, currentKey.toonPbrLevels, currentKey.toonPbrAlphas,
+                                                  currentKey.toonPbrCuts, currentKey.toonPbrLevels, currentKey.toonPbrAlphas, currentKey.toonPbrRampIntensity,
                                                   currentKey.envDiffuseStrength, currentKey.envSpecularStrength,
                                                   DirectX::XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
 
@@ -3403,7 +3411,7 @@ namespace Alice
                                           currentKey.roughness, currentKey.metalness, currentKey.ambientOcclusion,
                                           (currentKey.useTexture != 0), (currentKey.enableNormalMap != 0),
                                           currentKey.shadingMode, currentKey.normalStrength,
-                                          currentKey.toonPbrCuts, currentKey.toonPbrLevels, currentKey.toonPbrAlphas,
+                                          currentKey.toonPbrCuts, currentKey.toonPbrLevels, currentKey.toonPbrAlphas, currentKey.toonPbrRampIntensity,
                                           currentKey.envDiffuseStrength, currentKey.envSpecularStrength,
                                           DirectX::XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
 
@@ -3512,7 +3520,7 @@ namespace Alice
                                               0.5f, 0.0f, m_lightingParameters.ambientOcclusion,
                                               (diff != nullptr), (norm != nullptr),
                                               shadingMode,
-                                              1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(), DefaultToonPbrAlphas(),
+                                              1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(), DefaultToonPbrAlphas(), 0.0f,
                                               1.0f, 1.0f,
                                               DirectX::XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
 
@@ -3527,7 +3535,7 @@ namespace Alice
                         UpdatePerObjectCB(cameraIconWorld, view, proj, cameraColor,
                                           0.5f, 0.0f, m_lightingParameters.ambientOcclusion,
                                           false, false, shadingMode,
-                                          1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(), DefaultToonPbrAlphas(),
+                                          1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(), DefaultToonPbrAlphas(), 0.0f,
                                           1.0f, 1.0f,
                                           DirectX::XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
 
@@ -3950,6 +3958,7 @@ namespace Alice
                 key.toonPbrCuts = cmd.toonPbrCuts;
                 key.toonPbrLevels = cmd.toonPbrLevels;
                 key.toonPbrAlphas = cmd.toonPbrAlphas;
+                key.toonPbrRampIntensity = cmd.toonPbrRampIntensity;
                 key.shadingMode = objectShadingMode;
                 key.useTexture = (diff != nullptr) ? 1 : 0;
                 key.enableNormalMap = (norm != nullptr) ? 1 : 0;
@@ -3982,7 +3991,7 @@ namespace Alice
                                           batchKey.roughness, batchKey.metalness, batchKey.ambientOcclusion,
                                           (batchKey.useTexture != 0), (batchKey.enableNormalMap != 0),
                                           batchKey.shadingMode, batchKey.normalStrength,
-                                          batchKey.toonPbrCuts, batchKey.toonPbrLevels, batchKey.toonPbrAlphas,
+                                          batchKey.toonPbrCuts, batchKey.toonPbrLevels, batchKey.toonPbrAlphas, batchKey.toonPbrRampIntensity,
                                           batchKey.envDiffuseStrength, batchKey.envSpecularStrength,
                                           DirectX::XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
 
@@ -4036,7 +4045,7 @@ namespace Alice
                                       batchKey.roughness, batchKey.metalness, batchKey.ambientOcclusion,
                                       (batchKey.useTexture != 0), (batchKey.enableNormalMap != 0),
                                       batchKey.shadingMode, batchKey.normalStrength,
-                                      batchKey.toonPbrCuts, batchKey.toonPbrLevels, batchKey.toonPbrAlphas,
+                                      batchKey.toonPbrCuts, batchKey.toonPbrLevels, batchKey.toonPbrAlphas, batchKey.toonPbrRampIntensity,
                                       batchKey.envDiffuseStrength, batchKey.envSpecularStrength,
                                       DirectX::XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
 
@@ -4079,7 +4088,7 @@ namespace Alice
                     // Pass 1. 원본
                     UpdatePerObjectCB(cmd.world, view, proj, color, cmd.roughness, cmd.metalness, ao,
                                       (diff != nullptr), (norm != nullptr), objectShadingMode,
-                                      cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas,
+                                      cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas, cmd.toonPbrRampIntensity,
                                       cmd.envDiffuseStrength, cmd.envSpecularStrength,
                                       outlineColor, 0.0f);
                     m_context->DrawIndexed(sub.indexCount, sub.startIndex, cmd.baseVertex);
@@ -4090,7 +4099,7 @@ namespace Alice
                         m_context->RSSetState(m_rsCullFront.Get());
                         UpdatePerObjectCB(cmd.world, view, proj, color, cmd.roughness, cmd.metalness, ao,
                                           (diff != nullptr), (norm != nullptr), objectShadingMode,
-                                          cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas,
+                                          cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas, cmd.toonPbrRampIntensity,
                                           cmd.envDiffuseStrength, cmd.envSpecularStrength,
                                           outlineColor, outlineWidth);
                         m_context->DrawIndexed(sub.indexCount, sub.startIndex, cmd.baseVertex);
@@ -4107,7 +4116,7 @@ namespace Alice
                 // [Pass 1] 원본
                 UpdatePerObjectCB(cmd.world, view, proj, color, cmd.roughness, cmd.metalness, ao,
                                   (diff != nullptr), false, objectShadingMode,
-                                  cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas,
+                                  cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas, cmd.toonPbrRampIntensity,
                                   cmd.envDiffuseStrength, cmd.envSpecularStrength,
                                   outlineColor, 0.0f);
                 m_context->DrawIndexed(cmd.indexCount, cmd.startIndex, cmd.baseVertex);
@@ -4118,7 +4127,7 @@ namespace Alice
                     m_context->RSSetState(m_rsCullFront.Get());
                     UpdatePerObjectCB(cmd.world, view, proj, color, cmd.roughness, cmd.metalness, ao,
                                       (diff != nullptr), false, objectShadingMode,
-                                      cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas,
+                                      cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas, cmd.toonPbrRampIntensity,
                                       cmd.envDiffuseStrength, cmd.envSpecularStrength,
                                       outlineColor, outlineWidth);
                     m_context->DrawIndexed(cmd.indexCount, cmd.startIndex, cmd.baseVertex);
@@ -4155,7 +4164,7 @@ namespace Alice
                                   batchKey.roughness, batchKey.metalness, batchKey.ambientOcclusion,
                                   (batchKey.useTexture != 0), (batchKey.enableNormalMap != 0),
                                   batchKey.shadingMode, batchKey.normalStrength,
-                                  batchKey.toonPbrCuts, batchKey.toonPbrLevels, batchKey.toonPbrAlphas,
+                                  batchKey.toonPbrCuts, batchKey.toonPbrLevels, batchKey.toonPbrAlphas, batchKey.toonPbrRampIntensity,
                                   batchKey.envDiffuseStrength, batchKey.envSpecularStrength,
                                   DirectX::XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
 
@@ -4278,6 +4287,7 @@ namespace Alice
                                                  const DirectX::XMFLOAT4& toonPbrCuts,
                                                  const DirectX::XMFLOAT4& toonPbrLevels,
                                                  const DirectX::XMFLOAT4& toonPbrAlphas,
+                                                 float toonPbrRampIntensity,
                                                  float envDiffuseStrength,
                                                  float envSpecularStrength,
                                                  const XMFLOAT3& outlineColor,
@@ -4305,8 +4315,9 @@ namespace Alice
             XMFLOAT4 gToonPbrCuts;    // Offset: 256 -> 272
             XMFLOAT4 gToonPbrLevels;  // Offset: 272 -> 288
             XMFLOAT4 gToonPbrAlphas;  // Offset: 288 -> 304
-            XMFLOAT3 gOutlineColor;   // Offset: 304 -> 316
-            float    gOutlineWidth;   // Offset: 316 -> 320
+            float    gToonPbrRampIntensity; // Offset: 304 -> 308
+            XMFLOAT3 gOutlineColor;   // Offset: 308 -> 320
+            float    gOutlineWidth;   // Offset: 320 -> 324
         };
 
         D3D11_MAPPED_SUBRESOURCE mapped;
@@ -4333,6 +4344,7 @@ namespace Alice
             data->gToonPbrCuts = toonPbrCuts;
             data->gToonPbrLevels = toonPbrLevels;
             data->gToonPbrAlphas = toonPbrAlphas;
+            data->gToonPbrRampIntensity = toonPbrRampIntensity;
             data->gOutlineColor = outlineColor;
             data->gOutlineWidth = outlineWidth;
             m_context->Unmap(m_cbPerObject.Get(), 0);
@@ -4859,6 +4871,22 @@ namespace Alice
 
     void DeferredRenderSystem::ForceShadowUpdate()
     {
+        m_shadowCacheDirty = true;
+    }
+
+    void DeferredRenderSystem::ApplyShadowSettings(const ShadowSettings& settings)
+    {
+        ShadowSettings clamped = settings;
+        clamped.mapSizePx = (std::max)(256u, clamped.mapSizePx);
+        clamped.pcfRadius = std::clamp(clamped.pcfRadius, 0.0f, 3.0f);
+
+        const bool sizeChanged = (clamped.mapSizePx != m_shadowSettings.mapSizePx);
+        m_shadowSettings = clamped;
+
+        if (sizeChanged)
+        {
+            EnsureShadowMapResources();
+        }
         m_shadowCacheDirty = true;
     }
 

--- a/Engine/src/Runtime/Rendering/DeferredRenderSystem.cpp
+++ b/Engine/src/Runtime/Rendering/DeferredRenderSystem.cpp
@@ -118,6 +118,7 @@ namespace Alice
                 if (toonPbrAlphas.x != rhs.toonPbrAlphas.x) return toonPbrAlphas.x < rhs.toonPbrAlphas.x;
                 if (toonPbrAlphas.y != rhs.toonPbrAlphas.y) return toonPbrAlphas.y < rhs.toonPbrAlphas.y;
                 if (toonPbrAlphas.z != rhs.toonPbrAlphas.z) return toonPbrAlphas.z < rhs.toonPbrAlphas.z;
+                if (toonPbrAlphas.w != rhs.toonPbrAlphas.w) return toonPbrAlphas.w < rhs.toonPbrAlphas.w;
                 if (shadingMode != rhs.shadingMode) return shadingMode < rhs.shadingMode;
                 if (useTexture != rhs.useTexture) return useTexture < rhs.useTexture;
                 if (enableNormalMap != rhs.enableNormalMap) return enableNormalMap < rhs.enableNormalMap;
@@ -157,6 +158,7 @@ namespace Alice
             if (a.toonPbrAlphas.x != b.toonPbrAlphas.x) return false;
             if (a.toonPbrAlphas.y != b.toonPbrAlphas.y) return false;
             if (a.toonPbrAlphas.z != b.toonPbrAlphas.z) return false;
+            if (a.toonPbrAlphas.w != b.toonPbrAlphas.w) return false;
             if (a.shadingMode != b.shadingMode) return false;
             if (a.useTexture != b.useTexture) return false;
             if (a.enableNormalMap != b.enableNormalMap) return false;
@@ -175,7 +177,7 @@ namespace Alice
 
         inline DirectX::XMFLOAT4 DefaultToonPbrAlphas()
         {
-            return DirectX::XMFLOAT4(1.0f, 1.0f, 1.0f, 0.0f);
+            return DirectX::XMFLOAT4(1.0f, 1.0f, 1.0f, 1.0f);
         }
 
         // 인스턴스 월드 행렬(3x4) 생성용 헬퍼
@@ -1342,9 +1344,9 @@ namespace Alice
             return false;
 
         // Shadow CB (register(b4))
-        // float4x4(64) + float3(12) + int(4) + float3 pad(12) = 92 -> 96(16B align)
+        // float4x4(64) + float5(20) + int(4) + float2 pad(8) = 96(16B align)
         {
-            cbDesc.ByteWidth = sizeof(DirectX::XMMATRIX) + sizeof(float) * 3 + sizeof(int) + sizeof(float) * 3;
+            cbDesc.ByteWidth = sizeof(DirectX::XMMATRIX) + sizeof(float) * 7 + sizeof(int);
             cbDesc.ByteWidth = (cbDesc.ByteWidth + 15u) & ~15u;
             if (FAILED(m_device->CreateBuffer(&cbDesc, nullptr, m_cbShadow.ReleaseAndGetAddressOf())))
                 return false;
@@ -2954,7 +2956,7 @@ namespace Alice
                 toonCuts = XMFLOAT4(mat->toonPbrCut1, mat->toonPbrCut2, mat->toonPbrCut3, mat->toonPbrStrength);
                 toonLevels = XMFLOAT4(mat->toonPbrLevel1, mat->toonPbrLevel2, mat->toonPbrLevel3,
                     mat->toonPbrBlur ? 1.0f : 0.0f);
-                toonAlphas = XMFLOAT4(mat->toonPbrLevel1Alpha, mat->toonPbrLevel2Alpha, mat->toonPbrLevel3Alpha, 0.0f);
+                toonAlphas = XMFLOAT4(mat->toonPbrLevel1Alpha, mat->toonPbrLevel2Alpha, mat->toonPbrLevel3Alpha, mat->shadowStrength);
                 if (mat->shadingMode >= 0) objectShadingMode = mat->shadingMode;
                 if (!mat->albedoTexturePath.empty()) {
                     texSRV = GetOrCreateTexture(mat->albedoTexturePath);
@@ -3735,7 +3737,9 @@ namespace Alice
                 float mapSize;
                 float pcfRadius;
                 int   enabled;
-                float pad[3];
+                float shadowStrength;
+                float toonShadowStrength;
+                float pad[2];
             };
 
             ShadowCBData scb{};
@@ -3744,6 +3748,8 @@ namespace Alice
             scb.mapSize = (float)((m_shadowMapSizePxEffective > 0) ? m_shadowMapSizePxEffective : m_shadowSettings.mapSizePx);
             scb.pcfRadius = m_shadowSettings.pcfRadius;
             scb.enabled = m_shadowSettings.enabled ? 1 : 0;
+            scb.shadowStrength = m_lightingParameters.shadowStrength;
+            scb.toonShadowStrength = m_lightingParameters.toonShadowStrength;
 
             D3D11_MAPPED_SUBRESOURCE mapped{};
             if (SUCCEEDED(m_context->Map(m_cbShadow.Get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped)))

--- a/Engine/src/Runtime/Rendering/DeferredRenderSystem.cpp
+++ b/Engine/src/Runtime/Rendering/DeferredRenderSystem.cpp
@@ -7,6 +7,7 @@
 #include <DirectXTK/DDSTextureLoader.h>
 #include <filesystem>
 #include <vector>
+#include <cstdint>
 #include <cmath>
 #include <cfloat>
 #include <algorithm>
@@ -58,6 +59,109 @@ namespace Alice
                 }
             }
             return {};
+        }
+
+        static bool IsDDSHeader(const std::vector<std::uint8_t>& data)
+        {
+            return data.size() >= 4 &&
+                   data[0] == 'D' &&
+                   data[1] == 'D' &&
+                   data[2] == 'S' &&
+                   data[3] == ' ';
+        }
+
+        static ComPtr<ID3D11ShaderResourceView> LoadColorTextureSRV(
+            ResourceManager* resources,
+            ID3D11Device* device,
+            const std::filesystem::path& logicalPath)
+        {
+            ComPtr<ID3D11ShaderResourceView> outSrv;
+            if (!resources || !device || logicalPath.empty())
+            {
+                return outSrv;
+            }
+
+            std::vector<std::uint8_t> data;
+            if (!resources->LoadBinaryAuto(logicalPath, data) || data.empty())
+            {
+                return outSrv;
+            }
+
+            HRESULT hr = E_FAIL;
+            if (IsDDSHeader(data))
+            {
+                constexpr auto kDdsFlags = DirectX::DDS_LOADER_FORCE_SRGB;
+                hr = DirectX::CreateDDSTextureFromMemoryEx(
+                    device,
+                    data.data(),
+                    data.size(),
+                    0,
+                    D3D11_USAGE_DEFAULT,
+                    D3D11_BIND_SHADER_RESOURCE,
+                    0,
+                    0,
+                    kDdsFlags,
+                    nullptr,
+                    outSrv.GetAddressOf());
+
+                if (FAILED(hr))
+                {
+                    hr = DirectX::CreateDDSTextureFromMemory(
+                        device,
+                        data.data(),
+                        data.size(),
+                        nullptr,
+                        outSrv.GetAddressOf());
+                }
+            }
+            else
+            {
+                ComPtr<ID3D11DeviceContext> ctx;
+                device->GetImmediateContext(ctx.GetAddressOf());
+                ComPtr<ID3D11Resource> res;
+
+                hr = DirectX::CreateWICTextureFromMemoryEx(
+                    device,
+                    ctx.Get(),
+                    data.data(),
+                    data.size(),
+                    0,
+                    D3D11_USAGE_DEFAULT,
+                    D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET,
+                    0,
+                    D3D11_RESOURCE_MISC_GENERATE_MIPS,
+                    DirectX::WIC_LOADER_FORCE_SRGB,
+                    res.GetAddressOf(),
+                    outSrv.GetAddressOf());
+
+                if (SUCCEEDED(hr) && ctx && outSrv)
+                {
+                    ctx->GenerateMips(outSrv.Get());
+                }
+                else if (FAILED(hr))
+                {
+                    hr = DirectX::CreateWICTextureFromMemoryEx(
+                        device,
+                        ctx.Get(),
+                        data.data(),
+                        data.size(),
+                        0,
+                        D3D11_USAGE_DEFAULT,
+                        D3D11_BIND_SHADER_RESOURCE,
+                        0,
+                        0,
+                        DirectX::WIC_LOADER_FORCE_SRGB,
+                        nullptr,
+                        outSrv.GetAddressOf());
+                }
+            }
+
+            if (FAILED(hr))
+            {
+                outSrv.Reset();
+            }
+
+            return outSrv;
         }
 
         // 인스턴싱 배치 키 (재질/메시 기준)
@@ -4625,7 +4729,14 @@ namespace Alice
 
         if (!m_device || !m_resources) return nullptr;
 
-        auto srv = m_resources->LoadData<ID3D11ShaderResourceView>(std::filesystem::path(path), m_device.Get());
+        // Material albedo/decal 경로는 컬러 텍스처로 취급해 sRGB를 강제합니다.
+        // (PNG/JPG에 sRGB 메타데이터가 없는 경우에도 Blender와 유사한 색역을 유지)
+        auto srv = LoadColorTextureSRV(m_resources, m_device.Get(), std::filesystem::path(path));
+        if (!srv)
+        {
+            // 폴백: 기존 ResourceManager 경로
+            srv = m_resources->LoadData<ID3D11ShaderResourceView>(std::filesystem::path(path), m_device.Get());
+        }
 
         if (!srv)
         {

--- a/Engine/src/Runtime/Rendering/DeferredRenderSystem.cpp
+++ b/Engine/src/Runtime/Rendering/DeferredRenderSystem.cpp
@@ -80,6 +80,7 @@ namespace Alice
             float normalStrength = 1.0f;
             DirectX::XMFLOAT4 toonPbrCuts { 0.2f, 0.5f, 0.95f, 1.0f };
             DirectX::XMFLOAT4 toonPbrLevels { 0.1f, 0.4f, 0.7f, 0.0f };
+            DirectX::XMFLOAT4 toonPbrAlphas { 1.0f, 1.0f, 1.0f, 0.0f };
             int shadingMode = 0;
             int useTexture = 0;
             int enableNormalMap = 0;
@@ -114,6 +115,9 @@ namespace Alice
                 if (toonPbrLevels.y != rhs.toonPbrLevels.y) return toonPbrLevels.y < rhs.toonPbrLevels.y;
                 if (toonPbrLevels.z != rhs.toonPbrLevels.z) return toonPbrLevels.z < rhs.toonPbrLevels.z;
                 if (toonPbrLevels.w != rhs.toonPbrLevels.w) return toonPbrLevels.w < rhs.toonPbrLevels.w;
+                if (toonPbrAlphas.x != rhs.toonPbrAlphas.x) return toonPbrAlphas.x < rhs.toonPbrAlphas.x;
+                if (toonPbrAlphas.y != rhs.toonPbrAlphas.y) return toonPbrAlphas.y < rhs.toonPbrAlphas.y;
+                if (toonPbrAlphas.z != rhs.toonPbrAlphas.z) return toonPbrAlphas.z < rhs.toonPbrAlphas.z;
                 if (shadingMode != rhs.shadingMode) return shadingMode < rhs.shadingMode;
                 if (useTexture != rhs.useTexture) return useTexture < rhs.useTexture;
                 if (enableNormalMap != rhs.enableNormalMap) return enableNormalMap < rhs.enableNormalMap;
@@ -150,6 +154,9 @@ namespace Alice
             if (a.toonPbrLevels.y != b.toonPbrLevels.y) return false;
             if (a.toonPbrLevels.z != b.toonPbrLevels.z) return false;
             if (a.toonPbrLevels.w != b.toonPbrLevels.w) return false;
+            if (a.toonPbrAlphas.x != b.toonPbrAlphas.x) return false;
+            if (a.toonPbrAlphas.y != b.toonPbrAlphas.y) return false;
+            if (a.toonPbrAlphas.z != b.toonPbrAlphas.z) return false;
             if (a.shadingMode != b.shadingMode) return false;
             if (a.useTexture != b.useTexture) return false;
             if (a.enableNormalMap != b.enableNormalMap) return false;
@@ -164,6 +171,11 @@ namespace Alice
         inline DirectX::XMFLOAT4 DefaultToonPbrLevels()
         {
             return DirectX::XMFLOAT4(0.1f, 0.4f, 0.7f, 0.0f);
+        }
+
+        inline DirectX::XMFLOAT4 DefaultToonPbrAlphas()
+        {
+            return DirectX::XMFLOAT4(1.0f, 1.0f, 1.0f, 0.0f);
         }
 
         // 인스턴스 월드 행렬(3x4) 생성용 헬퍼
@@ -439,6 +451,7 @@ namespace Alice
             DXGI_FORMAT_R8G8B8A8_UNORM,      // 1: Metalness(R) + ToonCuts(GBA)
             DXGI_FORMAT_R8G8B8A8_UNORM_SRGB, // 2: BaseColor + ShadingMode(A)
             DXGI_FORMAT_R16G16B16A16_UNORM,  // 3: ToonParams (Strength/Levels/Env 2x8 packed)
+            DXGI_FORMAT_R8G8B8A8_UNORM,      // 4: ToonAlphas (level1~3 alpha)
         };
 
         // 각 G-Buffer 텍스처 생성
@@ -531,6 +544,7 @@ namespace Alice
             DXGI_FORMAT_R8G8B8A8_UNORM,      // 1: Metalness + ToonCuts
             DXGI_FORMAT_R8G8B8A8_UNORM_SRGB, // 2: BaseColor + ShadingMode
             DXGI_FORMAT_R16G16B16A16_UNORM,  // 3: ToonParams (Strength/Levels/Env 2x8 packed)
+            DXGI_FORMAT_R8G8B8A8_UNORM,      // 4: ToonAlphas (level1~3 alpha)
         };
 
         for (int i = 0; i < GBufferCount; ++i)
@@ -2105,7 +2119,7 @@ namespace Alice
                 else if (m_shadowRasterizerState) m_context->RSSetState(m_shadowRasterizerState.Get());
 
                 UpdatePerObjectCB(worldM, lightView, lightProj, XMFLOAT4(1, 1, 1, 1), 1.0f, 0.0f, 1.0f, false, false, 0,
-                                  1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(),
+                                  1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(), DefaultToonPbrAlphas(),
                                   1.0f, 1.0f,
                                   XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
                 m_context->DrawIndexed(m_cubeIndexCount, 0, 0);
@@ -2152,7 +2166,7 @@ namespace Alice
                                 m_context->IASetIndexBuffer(currentKey.indexBuffer, DXGI_FORMAT_R16_UINT, 0);
 
                                 UpdatePerObjectCB(DirectX::XMMatrixIdentity(), lightView, lightProj, XMFLOAT4(1, 1, 1, 1), 1.0f, 0.0f, 1.0f, false, false, 0,
-                                                  1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(),
+                                                  1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(), DefaultToonPbrAlphas(),
                                                   1.0f, 1.0f,
                                                   XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
                                 m_context->DrawIndexedInstanced(currentKey.indexCount, (UINT)batchInstances.size(),
@@ -2185,7 +2199,7 @@ namespace Alice
                         m_context->IASetIndexBuffer(currentKey.indexBuffer, DXGI_FORMAT_R16_UINT, 0);
 
                         UpdatePerObjectCB(DirectX::XMMatrixIdentity(), lightView, lightProj, XMFLOAT4(1, 1, 1, 1), 1.0f, 0.0f, 1.0f, false, false, 0,
-                                          1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(),
+                                          1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(), DefaultToonPbrAlphas(),
                                           1.0f, 1.0f,
                                           XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
                         m_context->DrawIndexedInstanced(currentKey.indexCount, (UINT)batchInstances.size(),
@@ -2296,7 +2310,7 @@ namespace Alice
 
                 UpdateBonesCB(cmd.bones, cmd.boneCount);
                 UpdatePerObjectCB(cmd.world, lightView, lightProj, XMFLOAT4(1, 1, 1, 1), 1.0f, 0.0f, 1.0f, false, false, 0,
-                                  1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(),
+                                  1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(), DefaultToonPbrAlphas(),
                                   1.0f, 1.0f, XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
                 m_context->DrawIndexed(cmd.indexCount, cmd.startIndex, cmd.baseVertex);
             }
@@ -2347,7 +2361,7 @@ namespace Alice
 
                                 // CB는 배치 단위로 1회만 갱신
                                 UpdatePerObjectCB(DirectX::XMMatrixIdentity(), lightView, lightProj, XMFLOAT4(1, 1, 1, 1), 1.0f, 0.0f, 1.0f, false, false, 0,
-                                                  1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(),
+                                                  1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(), DefaultToonPbrAlphas(),
                                                   1.0f, 1.0f,
                                                   XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
 
@@ -2381,7 +2395,7 @@ namespace Alice
                         m_context->IASetIndexBuffer(currentKey.indexBuffer, DXGI_FORMAT_R32_UINT, 0);
 
                         UpdatePerObjectCB(DirectX::XMMatrixIdentity(), lightView, lightProj, XMFLOAT4(1, 1, 1, 1), 1.0f, 0.0f, 1.0f, false, false, 0,
-                                          1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(),
+                                          1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(), DefaultToonPbrAlphas(),
                                           1.0f, 1.0f, XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
 
                         m_context->DrawIndexedInstanced(currentKey.indexCount, (UINT)batchInstances.size(), currentKey.startIndex, currentKey.baseVertex, 0);
@@ -2836,6 +2850,7 @@ namespace Alice
         m_context->ClearRenderTargetView(m_gBufferRTVs[1].Get(), clearColor);  // Metalness
         m_context->ClearRenderTargetView(m_gBufferRTVs[2].Get(), clearColor);  // BaseColor
         m_context->ClearRenderTargetView(m_gBufferRTVs[3].Get(), clearColor);  // ToonParams
+        m_context->ClearRenderTargetView(m_gBufferRTVs[4].Get(), clearColor);  // ToonAlphas
         m_context->ClearDepthStencilView(m_sceneDSV.Get(), D3D11_CLEAR_DEPTH | D3D11_CLEAR_STENCIL, 1.0f, 0);
 
         // G-Buffer 렌더 타겟 설정
@@ -2843,7 +2858,8 @@ namespace Alice
             m_gBufferRTVs[0].Get(),
             m_gBufferRTVs[1].Get(),
             m_gBufferRTVs[2].Get(),
-            m_gBufferRTVs[3].Get()
+            m_gBufferRTVs[3].Get(),
+            m_gBufferRTVs[4].Get()
         };
         m_context->OMSetRenderTargets(GBufferCount, rtvs, m_sceneDSV.Get());
         m_context->OMSetDepthStencilState(m_depthStencilState.Get(), 0);
@@ -2922,6 +2938,7 @@ namespace Alice
             float normalStrength = 1.0f;
             XMFLOAT4 toonCuts = DefaultToonPbrCuts();
             XMFLOAT4 toonLevels = DefaultToonPbrLevels();
+            XMFLOAT4 toonAlphas = DefaultToonPbrAlphas();
             int objectShadingMode = shadingMode;
             if (mat) {
                 color = { mat->color.x, mat->color.y, mat->color.z, mat->alpha };
@@ -2937,6 +2954,7 @@ namespace Alice
                 toonCuts = XMFLOAT4(mat->toonPbrCut1, mat->toonPbrCut2, mat->toonPbrCut3, mat->toonPbrStrength);
                 toonLevels = XMFLOAT4(mat->toonPbrLevel1, mat->toonPbrLevel2, mat->toonPbrLevel3,
                     mat->toonPbrBlur ? 1.0f : 0.0f);
+                toonAlphas = XMFLOAT4(mat->toonPbrLevel1Alpha, mat->toonPbrLevel2Alpha, mat->toonPbrLevel3Alpha, 0.0f);
                 if (mat->shadingMode >= 0) objectShadingMode = mat->shadingMode;
                 if (!mat->albedoTexturePath.empty()) {
                     texSRV = GetOrCreateTexture(mat->albedoTexturePath);
@@ -2969,6 +2987,7 @@ namespace Alice
                 item.key.normalStrength = normalStrength;
                 item.key.toonPbrCuts = toonCuts;
                 item.key.toonPbrLevels = toonLevels;
+                item.key.toonPbrAlphas = toonAlphas;
                 item.key.shadingMode = objectShadingMode;
                 item.key.useTexture = useTex ? 1 : 0;
                 item.key.enableNormalMap = 0;
@@ -2984,7 +3003,7 @@ namespace Alice
 
             // Pass 1. 원본 물체 그리기 (아웃라인 두께 0으로 강제)
             UpdatePerObjectCB(worldM, view, proj, color, rough, metal, ao, useTex, false,
-                              objectShadingMode, normalStrength, toonCuts, toonLevels,
+                              objectShadingMode, normalStrength, toonCuts, toonLevels, toonAlphas,
                               envDiffuseStrength, envSpecularStrength,
                               outlineColor, 0.0f); // width = 0
             m_context->DrawIndexed(m_cubeIndexCount, 0, 0);
@@ -2996,7 +3015,7 @@ namespace Alice
                 
                 // 아웃라인 값 적용
                 UpdatePerObjectCB(worldM, view, proj, color, rough, metal, ao, useTex, false,
-                                  objectShadingMode, normalStrength, toonCuts, toonLevels,
+                                  objectShadingMode, normalStrength, toonCuts, toonLevels, toonAlphas,
                                   envDiffuseStrength, envSpecularStrength,
                                   outlineColor, outlineWidth);
                 m_context->DrawIndexed(m_cubeIndexCount, 0, 0);
@@ -3048,7 +3067,7 @@ namespace Alice
                                               currentKey.roughness, currentKey.metalness, currentKey.ambientOcclusion,
                                               (currentKey.useTexture != 0), (currentKey.enableNormalMap != 0),
                                               currentKey.shadingMode, currentKey.normalStrength,
-                                              currentKey.toonPbrCuts, currentKey.toonPbrLevels,
+                                              currentKey.toonPbrCuts, currentKey.toonPbrLevels, currentKey.toonPbrAlphas,
                                               currentKey.envDiffuseStrength, currentKey.envSpecularStrength,
                                               DirectX::XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
 
@@ -3085,7 +3104,7 @@ namespace Alice
                                       currentKey.roughness, currentKey.metalness, currentKey.ambientOcclusion,
                                       (currentKey.useTexture != 0), (currentKey.enableNormalMap != 0),
                                       currentKey.shadingMode, currentKey.normalStrength,
-                                      currentKey.toonPbrCuts, currentKey.toonPbrLevels,
+                                      currentKey.toonPbrCuts, currentKey.toonPbrLevels, currentKey.toonPbrAlphas,
                                       currentKey.envDiffuseStrength, currentKey.envSpecularStrength,
                                       DirectX::XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
 
@@ -3186,6 +3205,7 @@ namespace Alice
                             item.key.normalStrength = cmd.normalStrength;
                             item.key.toonPbrCuts = cmd.toonPbrCuts;
                             item.key.toonPbrLevels = cmd.toonPbrLevels;
+                            item.key.toonPbrAlphas = cmd.toonPbrAlphas;
                             item.key.shadingMode = objectShadingMode;
                             item.key.useTexture = (diff != nullptr) ? 1 : 0;
                             item.key.enableNormalMap = (norm != nullptr) ? 1 : 0;
@@ -3217,6 +3237,7 @@ namespace Alice
                         item.key.normalStrength = cmd.normalStrength;
                         item.key.toonPbrCuts = cmd.toonPbrCuts;
                         item.key.toonPbrLevels = cmd.toonPbrLevels;
+                        item.key.toonPbrAlphas = cmd.toonPbrAlphas;
                         item.key.shadingMode = objectShadingMode;
                         item.key.useTexture = (diff != nullptr) ? 1 : 0;
                         item.key.enableNormalMap = 0;
@@ -3252,7 +3273,7 @@ namespace Alice
                         // Pass 1. 원본
                         UpdatePerObjectCB(cmd.world, view, proj, color, cmd.roughness, cmd.metalness, ao,
                                           (diff != nullptr), (norm != nullptr), objectShadingMode, 
-                                          cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels,
+                                          cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas,
                                           cmd.envDiffuseStrength, cmd.envSpecularStrength,
                                           cmd.outlineColor, 0.0f); // width 0
                         m_context->DrawIndexed(sub.indexCount, sub.startIndex, cmd.baseVertex);
@@ -3263,7 +3284,7 @@ namespace Alice
                             m_context->RSSetState(m_rsCullFront.Get());
                             UpdatePerObjectCB(cmd.world, view, proj, color, cmd.roughness, cmd.metalness, ao,
                                               (diff != nullptr), (norm != nullptr), objectShadingMode, 
-                                              cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels,
+                                              cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas,
                                               cmd.envDiffuseStrength, cmd.envSpecularStrength,
                                               cmd.outlineColor, cmd.outlineWidth);
                             m_context->DrawIndexed(sub.indexCount, sub.startIndex, cmd.baseVertex);
@@ -3281,7 +3302,7 @@ namespace Alice
                     // Pass 1. 원본
                     UpdatePerObjectCB(cmd.world, view, proj, color, cmd.roughness, cmd.metalness, ao,
                                       (diff != nullptr), false, objectShadingMode, 
-                                      cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels,
+                                      cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas,
                                       cmd.envDiffuseStrength, cmd.envSpecularStrength,
                                       cmd.outlineColor, 0.0f);
                     m_context->DrawIndexed(cmd.indexCount, cmd.startIndex, cmd.baseVertex);
@@ -3292,7 +3313,7 @@ namespace Alice
                         m_context->RSSetState(m_rsCullFront.Get());
                         UpdatePerObjectCB(cmd.world, view, proj, color, cmd.roughness, cmd.metalness, ao,
                                           (diff != nullptr), false, objectShadingMode, 
-                                          cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels,
+                                          cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas,
                                           cmd.envDiffuseStrength, cmd.envSpecularStrength,
                                           cmd.outlineColor, cmd.outlineWidth);
                         m_context->DrawIndexed(cmd.indexCount, cmd.startIndex, cmd.baseVertex);
@@ -3343,7 +3364,7 @@ namespace Alice
                                                   currentKey.roughness, currentKey.metalness, currentKey.ambientOcclusion,
                                                   (currentKey.useTexture != 0), (currentKey.enableNormalMap != 0),
                                                   currentKey.shadingMode, currentKey.normalStrength,
-                                                  currentKey.toonPbrCuts, currentKey.toonPbrLevels,
+                                                  currentKey.toonPbrCuts, currentKey.toonPbrLevels, currentKey.toonPbrAlphas,
                                                   currentKey.envDiffuseStrength, currentKey.envSpecularStrength,
                                                   DirectX::XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
 
@@ -3380,7 +3401,7 @@ namespace Alice
                                           currentKey.roughness, currentKey.metalness, currentKey.ambientOcclusion,
                                           (currentKey.useTexture != 0), (currentKey.enableNormalMap != 0),
                                           currentKey.shadingMode, currentKey.normalStrength,
-                                          currentKey.toonPbrCuts, currentKey.toonPbrLevels,
+                                          currentKey.toonPbrCuts, currentKey.toonPbrLevels, currentKey.toonPbrAlphas,
                                           currentKey.envDiffuseStrength, currentKey.envSpecularStrength,
                                           DirectX::XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
 
@@ -3489,7 +3510,7 @@ namespace Alice
                                               0.5f, 0.0f, m_lightingParameters.ambientOcclusion,
                                               (diff != nullptr), (norm != nullptr),
                                               shadingMode,
-                                              1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(),
+                                              1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(), DefaultToonPbrAlphas(),
                                               1.0f, 1.0f,
                                               DirectX::XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
 
@@ -3504,7 +3525,7 @@ namespace Alice
                         UpdatePerObjectCB(cameraIconWorld, view, proj, cameraColor,
                                           0.5f, 0.0f, m_lightingParameters.ambientOcclusion,
                                           false, false, shadingMode,
-                                          1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(),
+                                          1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(), DefaultToonPbrAlphas(),
                                           1.0f, 1.0f,
                                           DirectX::XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
 
@@ -3685,6 +3706,7 @@ namespace Alice
             m_gBufferSRVs[1].Get(), // Metalness
             m_gBufferSRVs[2].Get(), // BaseColor
             m_gBufferSRVs[3].Get(), // ToonParams
+            m_gBufferSRVs[4].Get(), // ToonAlphas
             m_sceneDepthSRV.Get(),  // Scene Depth (Position 복원용)
             m_iblDiffuseSRV.Get(),   // IBL Diffuse
             m_iblSpecularSRV.Get(),  // IBL Specular
@@ -3746,8 +3768,8 @@ namespace Alice
         m_context->DrawIndexed(m_quadIndexCount, 0, 0);
 
         // 리소스 해제
-        ID3D11ShaderResourceView* nullSRVs[10] = { nullptr };
-        m_context->PSSetShaderResources(0, 10, nullSRVs);
+        ID3D11ShaderResourceView* nullSRVs[11] = { nullptr };
+        m_context->PSSetShaderResources(0, 11, nullSRVs);
     }
 
     void DeferredRenderSystem::PassTransparentForward(
@@ -3921,6 +3943,7 @@ namespace Alice
                 key.normalStrength = cmd.normalStrength;
                 key.toonPbrCuts = cmd.toonPbrCuts;
                 key.toonPbrLevels = cmd.toonPbrLevels;
+                key.toonPbrAlphas = cmd.toonPbrAlphas;
                 key.shadingMode = objectShadingMode;
                 key.useTexture = (diff != nullptr) ? 1 : 0;
                 key.enableNormalMap = (norm != nullptr) ? 1 : 0;
@@ -3953,7 +3976,7 @@ namespace Alice
                                           batchKey.roughness, batchKey.metalness, batchKey.ambientOcclusion,
                                           (batchKey.useTexture != 0), (batchKey.enableNormalMap != 0),
                                           batchKey.shadingMode, batchKey.normalStrength,
-                                          batchKey.toonPbrCuts, batchKey.toonPbrLevels,
+                                          batchKey.toonPbrCuts, batchKey.toonPbrLevels, batchKey.toonPbrAlphas,
                                           batchKey.envDiffuseStrength, batchKey.envSpecularStrength,
                                           DirectX::XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
 
@@ -4007,7 +4030,7 @@ namespace Alice
                                       batchKey.roughness, batchKey.metalness, batchKey.ambientOcclusion,
                                       (batchKey.useTexture != 0), (batchKey.enableNormalMap != 0),
                                       batchKey.shadingMode, batchKey.normalStrength,
-                                      batchKey.toonPbrCuts, batchKey.toonPbrLevels,
+                                      batchKey.toonPbrCuts, batchKey.toonPbrLevels, batchKey.toonPbrAlphas,
                                       batchKey.envDiffuseStrength, batchKey.envSpecularStrength,
                                       DirectX::XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
 
@@ -4050,7 +4073,7 @@ namespace Alice
                     // Pass 1. 원본
                     UpdatePerObjectCB(cmd.world, view, proj, color, cmd.roughness, cmd.metalness, ao,
                                       (diff != nullptr), (norm != nullptr), objectShadingMode,
-                                      cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels,
+                                      cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas,
                                       cmd.envDiffuseStrength, cmd.envSpecularStrength,
                                       outlineColor, 0.0f);
                     m_context->DrawIndexed(sub.indexCount, sub.startIndex, cmd.baseVertex);
@@ -4061,7 +4084,7 @@ namespace Alice
                         m_context->RSSetState(m_rsCullFront.Get());
                         UpdatePerObjectCB(cmd.world, view, proj, color, cmd.roughness, cmd.metalness, ao,
                                           (diff != nullptr), (norm != nullptr), objectShadingMode,
-                                          cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels,
+                                          cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas,
                                           cmd.envDiffuseStrength, cmd.envSpecularStrength,
                                           outlineColor, outlineWidth);
                         m_context->DrawIndexed(sub.indexCount, sub.startIndex, cmd.baseVertex);
@@ -4078,7 +4101,7 @@ namespace Alice
                 // [Pass 1] 원본
                 UpdatePerObjectCB(cmd.world, view, proj, color, cmd.roughness, cmd.metalness, ao,
                                   (diff != nullptr), false, objectShadingMode,
-                                  cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels,
+                                  cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas,
                                   cmd.envDiffuseStrength, cmd.envSpecularStrength,
                                   outlineColor, 0.0f);
                 m_context->DrawIndexed(cmd.indexCount, cmd.startIndex, cmd.baseVertex);
@@ -4089,7 +4112,7 @@ namespace Alice
                     m_context->RSSetState(m_rsCullFront.Get());
                     UpdatePerObjectCB(cmd.world, view, proj, color, cmd.roughness, cmd.metalness, ao,
                                       (diff != nullptr), false, objectShadingMode,
-                                      cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels,
+                                      cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas,
                                       cmd.envDiffuseStrength, cmd.envSpecularStrength,
                                       outlineColor, outlineWidth);
                     m_context->DrawIndexed(cmd.indexCount, cmd.startIndex, cmd.baseVertex);
@@ -4126,7 +4149,7 @@ namespace Alice
                                   batchKey.roughness, batchKey.metalness, batchKey.ambientOcclusion,
                                   (batchKey.useTexture != 0), (batchKey.enableNormalMap != 0),
                                   batchKey.shadingMode, batchKey.normalStrength,
-                                  batchKey.toonPbrCuts, batchKey.toonPbrLevels,
+                                  batchKey.toonPbrCuts, batchKey.toonPbrLevels, batchKey.toonPbrAlphas,
                                   batchKey.envDiffuseStrength, batchKey.envSpecularStrength,
                                   DirectX::XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
 
@@ -4248,6 +4271,7 @@ namespace Alice
                                                  float normalStrength,
                                                  const DirectX::XMFLOAT4& toonPbrCuts,
                                                  const DirectX::XMFLOAT4& toonPbrLevels,
+                                                 const DirectX::XMFLOAT4& toonPbrAlphas,
                                                  float envDiffuseStrength,
                                                  float envSpecularStrength,
                                                  const XMFLOAT3& outlineColor,
@@ -4274,8 +4298,9 @@ namespace Alice
             float    gEnvSpecularStrength; // Offset: 252 -> 256
             XMFLOAT4 gToonPbrCuts;    // Offset: 256 -> 272
             XMFLOAT4 gToonPbrLevels;  // Offset: 272 -> 288
-            XMFLOAT3 gOutlineColor;   // Offset: 288 -> 300
-            float    gOutlineWidth;   // Offset: 300 -> 304
+            XMFLOAT4 gToonPbrAlphas;  // Offset: 288 -> 304
+            XMFLOAT3 gOutlineColor;   // Offset: 304 -> 316
+            float    gOutlineWidth;   // Offset: 316 -> 320
         };
 
         D3D11_MAPPED_SUBRESOURCE mapped;
@@ -4301,6 +4326,7 @@ namespace Alice
             data->gEnvSpecularStrength = envSpecularStrength;
             data->gToonPbrCuts = toonPbrCuts;
             data->gToonPbrLevels = toonPbrLevels;
+            data->gToonPbrAlphas = toonPbrAlphas;
             data->gOutlineColor = outlineColor;
             data->gOutlineWidth = outlineWidth;
             m_context->Unmap(m_cbPerObject.Get(), 0);

--- a/Engine/src/Runtime/Rendering/DeferredRenderSystem.h
+++ b/Engine/src/Runtime/Rendering/DeferredRenderSystem.h
@@ -213,8 +213,8 @@ namespace Alice
 
         /// 백버퍼로 렌더 타겟을 복귀시킵니다 (ImGui 등 후처리를 위해).
         void RestoreBackBuffer();
-        // G-Buffer 개수 (Normal+Roughness, Metalness+ToonCuts, BaseColor, ToonParams)
-        static constexpr int GBufferCount = 4;
+        // G-Buffer 개수 (Normal+Roughness, Metalness+ToonCuts, BaseColor, ToonParams, ToonAlphas)
+        static constexpr int GBufferCount = 5;
         // D-Buffer 개수 (Decal Albedo)
         static constexpr int DBufferCount = 1;
 
@@ -287,6 +287,7 @@ namespace Alice
                                float normalStrength,
                                const DirectX::XMFLOAT4& toonPbrCuts,
                                const DirectX::XMFLOAT4& toonPbrLevels,
+                               const DirectX::XMFLOAT4& toonPbrAlphas,
                                float envDiffuseStrength = 1.0f,
                                float envSpecularStrength = 1.0f,
                                const DirectX::XMFLOAT3& outlineColor = DirectX::XMFLOAT3(0.0f, 0.0f, 0.0f),

--- a/Engine/src/Runtime/Rendering/DeferredRenderSystem.h
+++ b/Engine/src/Runtime/Rendering/DeferredRenderSystem.h
@@ -117,6 +117,10 @@ namespace Alice
         void SetShadowResolutionScale(std::uint32_t scale);
         /// Shadow 맵 강제 갱신 플래그.
         void ForceShadowUpdate();
+        /// Shadow 설정을 반환합니다.
+        const ShadowSettings& GetShadowSettings() const { return m_shadowSettings; }
+        /// Shadow 설정을 적용합니다. (해상도 변경 시 리소스를 재생성)
+        void ApplyShadowSettings(const ShadowSettings& settings);
 
         /// 배경색을 설정합니다 (스카이박스가 Off일 때 사용).
         void SetBackgroundColor(const DirectX::XMFLOAT4& color) { m_backgroundColor = color; }
@@ -288,6 +292,7 @@ namespace Alice
                                const DirectX::XMFLOAT4& toonPbrCuts,
                                const DirectX::XMFLOAT4& toonPbrLevels,
                                const DirectX::XMFLOAT4& toonPbrAlphas,
+                               float toonPbrRampIntensity,
                                float envDiffuseStrength = 1.0f,
                                float envSpecularStrength = 1.0f,
                                const DirectX::XMFLOAT3& outlineColor = DirectX::XMFLOAT3(0.0f, 0.0f, 0.0f),
@@ -525,7 +530,7 @@ namespace Alice
         bool                                            m_shadowCacheDirty = true;
         bool                                            m_shadowEnabledLast = true;
         std::uint32_t                                   m_shadowUpdateInterval = 2; // 1: 매 프레임
-        std::uint32_t                                   m_shadowResolutionScale = 2; // 1: 원본, 2: 1/2
+        std::uint32_t                                   m_shadowResolutionScale = 1; // 1: 원본, 2: 1/2
         std::uint32_t                                   m_shadowMapSizePxEffective = 0;
 
         // Forward와 동일한 조명/재질 파라미터 (에디터 UI 공유)

--- a/Engine/src/Runtime/Rendering/DeferredRenderSystem.h
+++ b/Engine/src/Runtime/Rendering/DeferredRenderSystem.h
@@ -293,6 +293,7 @@ namespace Alice
                                const DirectX::XMFLOAT4& toonPbrLevels,
                                const DirectX::XMFLOAT4& toonPbrAlphas,
                                float toonPbrRampIntensity,
+                               float toonSelfShadowStrength,
                                float envDiffuseStrength = 1.0f,
                                float envSpecularStrength = 1.0f,
                                const DirectX::XMFLOAT3& outlineColor = DirectX::XMFLOAT3(0.0f, 0.0f, 0.0f),

--- a/Engine/src/Runtime/Rendering/ForwardRenderSystem.cpp
+++ b/Engine/src/Runtime/Rendering/ForwardRenderSystem.cpp
@@ -69,6 +69,7 @@ namespace Alice
             float normalStrength = 1.0f;
             DirectX::XMFLOAT4 toonPbrCuts { 0.2f, 0.5f, 0.95f, 1.0f };
             DirectX::XMFLOAT4 toonPbrLevels { 0.1f, 0.4f, 0.7f, 0.0f };
+            DirectX::XMFLOAT4 toonPbrAlphas { 1.0f, 1.0f, 1.0f, 0.0f };
             int shadingMode = 0;
             int useTexture = 0;
             int enableNormalMap = 0;
@@ -104,6 +105,9 @@ namespace Alice
                 if (toonPbrLevels.y != rhs.toonPbrLevels.y) return toonPbrLevels.y < rhs.toonPbrLevels.y;
                 if (toonPbrLevels.z != rhs.toonPbrLevels.z) return toonPbrLevels.z < rhs.toonPbrLevels.z;
                 if (toonPbrLevels.w != rhs.toonPbrLevels.w) return toonPbrLevels.w < rhs.toonPbrLevels.w;
+                if (toonPbrAlphas.x != rhs.toonPbrAlphas.x) return toonPbrAlphas.x < rhs.toonPbrAlphas.x;
+                if (toonPbrAlphas.y != rhs.toonPbrAlphas.y) return toonPbrAlphas.y < rhs.toonPbrAlphas.y;
+                if (toonPbrAlphas.z != rhs.toonPbrAlphas.z) return toonPbrAlphas.z < rhs.toonPbrAlphas.z;
                 if (shadingMode != rhs.shadingMode) return shadingMode < rhs.shadingMode;
                 if (useTexture != rhs.useTexture) return useTexture < rhs.useTexture;
                 if (enableNormalMap != rhs.enableNormalMap) return enableNormalMap < rhs.enableNormalMap;
@@ -141,6 +145,9 @@ namespace Alice
             if (a.toonPbrLevels.y != b.toonPbrLevels.y) return false;
             if (a.toonPbrLevels.z != b.toonPbrLevels.z) return false;
             if (a.toonPbrLevels.w != b.toonPbrLevels.w) return false;
+            if (a.toonPbrAlphas.x != b.toonPbrAlphas.x) return false;
+            if (a.toonPbrAlphas.y != b.toonPbrAlphas.y) return false;
+            if (a.toonPbrAlphas.z != b.toonPbrAlphas.z) return false;
             if (a.shadingMode != b.shadingMode) return false;
             if (a.useTexture != b.useTexture) return false;
             if (a.enableNormalMap != b.enableNormalMap) return false;
@@ -156,6 +163,11 @@ namespace Alice
         inline DirectX::XMFLOAT4 DefaultToonPbrLevels()
         {
             return DirectX::XMFLOAT4(0.1f, 0.4f, 0.7f, 0.0f);
+        }
+
+        inline DirectX::XMFLOAT4 DefaultToonPbrAlphas()
+        {
+            return DirectX::XMFLOAT4(1.0f, 1.0f, 1.0f, 0.0f);
         }
 
         // 인스턴스 월드 행렬(3x4) 생성용 헬퍼
@@ -939,6 +951,7 @@ namespace Alice
                                                 float normalStrength,
                                                 const XMFLOAT4& toonPbrCuts,
                                                 const XMFLOAT4& toonPbrLevels,
+                                                const XMFLOAT4& toonPbrAlphas,
                                                 float envDiffuseStrength,
                                                 float envSpecularStrength,
                                                 const XMFLOAT3& outlineColor,
@@ -960,6 +973,7 @@ namespace Alice
         data.normalStrength = normalStrength;
         data.toonPbrCuts = toonPbrCuts;
         data.toonPbrLevels = toonPbrLevels;
+        data.toonPbrAlphas = toonPbrAlphas;
         data.envDiffuseStrength = envDiffuseStrength;
         data.envSpecularStrength = envSpecularStrength;
         data.outlineColor  = outlineColor;
@@ -1313,6 +1327,7 @@ namespace Alice
                 key.normalStrength = cmd.normalStrength;
                 key.toonPbrCuts = cmd.toonPbrCuts;
                 key.toonPbrLevels = cmd.toonPbrLevels;
+                key.toonPbrAlphas = cmd.toonPbrAlphas;
                 key.shadingMode = objectShadingMode;
                 key.useTexture = 1;
                 key.enableNormalMap = (norm != nullptr) ? 1 : 0;
@@ -1356,7 +1371,7 @@ namespace Alice
                                           batchKey.color, batchKey.roughness, batchKey.metalness, batchKey.ambientOcclusion,
                                           true, (batchKey.enableNormalMap != 0),
                                           batchKey.shadingMode, batchKey.normalStrength,
-                                          batchKey.toonPbrCuts, batchKey.toonPbrLevels,
+                                          batchKey.toonPbrCuts, batchKey.toonPbrLevels, batchKey.toonPbrAlphas,
                                           batchKey.envDiffuseStrength, batchKey.envSpecularStrength,
                                           XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
 
@@ -1420,7 +1435,7 @@ namespace Alice
                                       batchKey.color, batchKey.roughness, batchKey.metalness, batchKey.ambientOcclusion,
                                       true, (batchKey.enableNormalMap != 0),
                                       batchKey.shadingMode, batchKey.normalStrength,
-                                      batchKey.toonPbrCuts, batchKey.toonPbrLevels,
+                                      batchKey.toonPbrCuts, batchKey.toonPbrLevels, batchKey.toonPbrAlphas,
                                       batchKey.envDiffuseStrength, batchKey.envSpecularStrength,
                                       XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
 
@@ -1467,7 +1482,7 @@ namespace Alice
                     // [Pass 1] 원본
                     UpdatePerObjectCB(cmd.world, view, proj,
                         XMFLOAT4(cmd.color.x, cmd.color.y, cmd.color.z, cmd.alpha), r, m, ao, true, (m_flatNormalSRV != nullptr),
-                        objectShadingMode, cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels,
+                        objectShadingMode, cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas,
                         cmd.envDiffuseStrength, cmd.envSpecularStrength,
                         outlineColor, 0.0f);
                     m_context->DrawIndexed(sub.indexCount, sub.startIndex, cmd.baseVertex);
@@ -1478,7 +1493,7 @@ namespace Alice
                         m_context->RSSetState(m_rsCullFront.Get());
                         UpdatePerObjectCB(cmd.world, view, proj,
                             XMFLOAT4(cmd.color.x, cmd.color.y, cmd.color.z, cmd.alpha), r, m, ao, true, (m_flatNormalSRV != nullptr),
-                            objectShadingMode, cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels,
+                            objectShadingMode, cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas,
                             cmd.envDiffuseStrength, cmd.envSpecularStrength,
                             outlineColor, outlineWidth);
                         m_context->DrawIndexed(sub.indexCount, sub.startIndex, cmd.baseVertex);
@@ -1499,7 +1514,7 @@ namespace Alice
                 // [Pass 1] 원본
                 UpdatePerObjectCB(cmd.world, view, proj,
                     XMFLOAT4(cmd.color.x, cmd.color.y, cmd.color.z, cmd.alpha), r, m, ao, true, (m_flatNormalSRV != nullptr),
-                    objectShadingMode, cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels,
+                    objectShadingMode, cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas,
                     cmd.envDiffuseStrength, cmd.envSpecularStrength,
                     outlineColor, 0.0f);
                 m_context->DrawIndexed(cmd.indexCount, cmd.startIndex, cmd.baseVertex);
@@ -1510,7 +1525,7 @@ namespace Alice
                     m_context->RSSetState(m_rsCullFront.Get());
                     UpdatePerObjectCB(cmd.world, view, proj,
                         XMFLOAT4(cmd.color.x, cmd.color.y, cmd.color.z, cmd.alpha), r, m, ao, true, (m_flatNormalSRV != nullptr),
-                        objectShadingMode, cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels,
+                        objectShadingMode, cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas,
                         cmd.envDiffuseStrength, cmd.envSpecularStrength,
                         outlineColor, outlineWidth);
                     m_context->DrawIndexed(cmd.indexCount, cmd.startIndex, cmd.baseVertex);
@@ -1558,7 +1573,7 @@ namespace Alice
                                   batchKey.color, batchKey.roughness, batchKey.metalness, batchKey.ambientOcclusion,
                                   true, (batchKey.enableNormalMap != 0),
                                   batchKey.shadingMode, batchKey.normalStrength,
-                                  batchKey.toonPbrCuts, batchKey.toonPbrLevels,
+                                  batchKey.toonPbrCuts, batchKey.toonPbrLevels, batchKey.toonPbrAlphas,
                                   batchKey.envDiffuseStrength, batchKey.envSpecularStrength,
                                   XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
 
@@ -1752,7 +1767,7 @@ namespace Alice
 
                 XMFLOAT4 dummy(1, 1, 1, 1);
                 UpdatePerObjectCB(worldM, lightView, lightProj, dummy, 1, 0, 1.0f, false, false, 0,
-                                  1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(),
+                                  1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(), DefaultToonPbrAlphas(),
                                   1.0f, 1.0f,
                                   XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
                 //m_context->DrawIndexed(m_indexCount, 0, 0);
@@ -1825,7 +1840,7 @@ namespace Alice
                     UpdateBonesCB(cmd.bones, cmd.boneCount);
                     XMFLOAT4 dummy(1, 1, 1, 1);
                     UpdatePerObjectCB(cmd.world, lightView, lightProj, dummy, 1, 0, 1.0f, false, false, 0,
-                                      1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(),
+                                      1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(), DefaultToonPbrAlphas(),
                                       1.0f, 1.0f,
                                       XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
                     m_context->DrawIndexed(cmd.indexCount, cmd.startIndex, cmd.baseVertex);
@@ -1869,7 +1884,7 @@ namespace Alice
 
                                     XMFLOAT4 dummy(1, 1, 1, 1);
                                     UpdatePerObjectCB(DirectX::XMMatrixIdentity(), lightView, lightProj, dummy, 1, 0, 1.0f, false, false, 0,
-                                                      1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(),
+                                                      1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(), DefaultToonPbrAlphas(),
                                                       1.0f, 1.0f,
                                                       XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
                                     m_context->DrawIndexedInstanced(currentKey.indexCount, (UINT)batchInstances.size(), currentKey.startIndex, currentKey.baseVertex, 0);
@@ -1899,7 +1914,7 @@ namespace Alice
 
                             XMFLOAT4 dummy(1, 1, 1, 1);
                             UpdatePerObjectCB(DirectX::XMMatrixIdentity(), lightView, lightProj, dummy, 1, 0, 1.0f, false, false, 0,
-                                              1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(),
+                                              1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(), DefaultToonPbrAlphas(),
                                               1.0f, 1.0f,
                                               XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
                             m_context->DrawIndexedInstanced(currentKey.indexCount, (UINT)batchInstances.size(), currentKey.startIndex, currentKey.baseVertex, 0);
@@ -1996,6 +2011,7 @@ namespace Alice
             float normalStrength = 1.0f;
             XMFLOAT4 toonCuts = DefaultToonPbrCuts();
             XMFLOAT4 toonLevels = DefaultToonPbrLevels();
+            XMFLOAT4 toonAlphas = DefaultToonPbrAlphas();
 
             if (mat) {
                 color = { mat->color.x, mat->color.y, mat->color.z, mat->alpha };
@@ -2008,6 +2024,7 @@ namespace Alice
                 toonCuts = XMFLOAT4(mat->toonPbrCut1, mat->toonPbrCut2, mat->toonPbrCut3, mat->toonPbrStrength);
                 toonLevels = XMFLOAT4(mat->toonPbrLevel1, mat->toonPbrLevel2, mat->toonPbrLevel3,
                     mat->toonPbrBlur ? 1.0f : 0.0f);
+                toonAlphas = XMFLOAT4(mat->toonPbrLevel1Alpha, mat->toonPbrLevel2Alpha, mat->toonPbrLevel3Alpha, 0.0f);
                 useTex = !mat->albedoTexturePath.empty();
             }
             const int objectShadingMode = (mat && mat->shadingMode >= 0) ? mat->shadingMode : shadingMode;
@@ -2039,7 +2056,7 @@ namespace Alice
             
             // [Pass 1] 원본 물체 그리기 (아웃라인 두께 0으로 강제)
             UpdatePerObjectCB(worldM, viewM, projM, color, rough, metal, ao, useTex, useNormalMap,
-                              objectShadingMode, normalStrength, toonCuts, toonLevels,
+                              objectShadingMode, normalStrength, toonCuts, toonLevels, toonAlphas,
                               envDiffuseStrength, envSpecularStrength,
                               outlineColor, 0.0f);
             m_context->DrawIndexed(m_indexCount, 0, 0);
@@ -2051,7 +2068,7 @@ namespace Alice
                 
                 // 아웃라인 값 적용
                 UpdatePerObjectCB(worldM, viewM, projM, color, rough, metal, ao, useTex, useNormalMap,
-                                  objectShadingMode, normalStrength, toonCuts, toonLevels,
+                                  objectShadingMode, normalStrength, toonCuts, toonLevels, toonAlphas,
                                   envDiffuseStrength, envSpecularStrength,
                                   outlineColor, outlineWidth);
                 m_context->DrawIndexed(m_indexCount, 0, 0);

--- a/Engine/src/Runtime/Rendering/ForwardRenderSystem.cpp
+++ b/Engine/src/Runtime/Rendering/ForwardRenderSystem.cpp
@@ -108,6 +108,7 @@ namespace Alice
                 if (toonPbrAlphas.x != rhs.toonPbrAlphas.x) return toonPbrAlphas.x < rhs.toonPbrAlphas.x;
                 if (toonPbrAlphas.y != rhs.toonPbrAlphas.y) return toonPbrAlphas.y < rhs.toonPbrAlphas.y;
                 if (toonPbrAlphas.z != rhs.toonPbrAlphas.z) return toonPbrAlphas.z < rhs.toonPbrAlphas.z;
+                if (toonPbrAlphas.w != rhs.toonPbrAlphas.w) return toonPbrAlphas.w < rhs.toonPbrAlphas.w;
                 if (shadingMode != rhs.shadingMode) return shadingMode < rhs.shadingMode;
                 if (useTexture != rhs.useTexture) return useTexture < rhs.useTexture;
                 if (enableNormalMap != rhs.enableNormalMap) return enableNormalMap < rhs.enableNormalMap;
@@ -148,6 +149,7 @@ namespace Alice
             if (a.toonPbrAlphas.x != b.toonPbrAlphas.x) return false;
             if (a.toonPbrAlphas.y != b.toonPbrAlphas.y) return false;
             if (a.toonPbrAlphas.z != b.toonPbrAlphas.z) return false;
+            if (a.toonPbrAlphas.w != b.toonPbrAlphas.w) return false;
             if (a.shadingMode != b.shadingMode) return false;
             if (a.useTexture != b.useTexture) return false;
             if (a.enableNormalMap != b.enableNormalMap) return false;
@@ -167,7 +169,7 @@ namespace Alice
 
         inline DirectX::XMFLOAT4 DefaultToonPbrAlphas()
         {
-            return DirectX::XMFLOAT4(1.0f, 1.0f, 1.0f, 0.0f);
+            return DirectX::XMFLOAT4(1.0f, 1.0f, 1.0f, 1.0f);
         }
 
         // 인스턴스 월드 행렬(3x4) 생성용 헬퍼
@@ -1048,6 +1050,10 @@ namespace Alice
         data.shadowMapSize = (float)m_shadowSettings.mapSizePx;
         data.shadowPcfRadius = m_shadowSettings.pcfRadius;
         data.shadowEnabled = m_shadowSettings.enabled;
+        data.shadowStrength = m_lightingParameters.shadowStrength;
+        data.toonShadowStrength = m_lightingParameters.toonShadowStrength;
+        data.shadowPad[0] = 0.0f;
+        data.shadowPad[1] = 0.0f;
 
         // GPU 업데이트 및 바인딩 (VS/PS 슬롯 1번)
         m_context->UpdateSubresource(m_cbLighting.Get(), 0, nullptr, &data, 0, 0);
@@ -2024,7 +2030,7 @@ namespace Alice
                 toonCuts = XMFLOAT4(mat->toonPbrCut1, mat->toonPbrCut2, mat->toonPbrCut3, mat->toonPbrStrength);
                 toonLevels = XMFLOAT4(mat->toonPbrLevel1, mat->toonPbrLevel2, mat->toonPbrLevel3,
                     mat->toonPbrBlur ? 1.0f : 0.0f);
-                toonAlphas = XMFLOAT4(mat->toonPbrLevel1Alpha, mat->toonPbrLevel2Alpha, mat->toonPbrLevel3Alpha, 0.0f);
+                toonAlphas = XMFLOAT4(mat->toonPbrLevel1Alpha, mat->toonPbrLevel2Alpha, mat->toonPbrLevel3Alpha, mat->shadowStrength);
                 useTex = !mat->albedoTexturePath.empty();
             }
             const int objectShadingMode = (mat && mat->shadingMode >= 0) ? mat->shadingMode : shadingMode;

--- a/Engine/src/Runtime/Rendering/ForwardRenderSystem.cpp
+++ b/Engine/src/Runtime/Rendering/ForwardRenderSystem.cpp
@@ -70,6 +70,7 @@ namespace Alice
             DirectX::XMFLOAT4 toonPbrCuts { 0.2f, 0.5f, 0.95f, 1.0f };
             DirectX::XMFLOAT4 toonPbrLevels { 0.1f, 0.4f, 0.7f, 0.0f };
             DirectX::XMFLOAT4 toonPbrAlphas { 1.0f, 1.0f, 1.0f, 0.0f };
+            float toonPbrRampIntensity = 0.0f;
             int shadingMode = 0;
             int useTexture = 0;
             int enableNormalMap = 0;
@@ -109,6 +110,7 @@ namespace Alice
                 if (toonPbrAlphas.y != rhs.toonPbrAlphas.y) return toonPbrAlphas.y < rhs.toonPbrAlphas.y;
                 if (toonPbrAlphas.z != rhs.toonPbrAlphas.z) return toonPbrAlphas.z < rhs.toonPbrAlphas.z;
                 if (toonPbrAlphas.w != rhs.toonPbrAlphas.w) return toonPbrAlphas.w < rhs.toonPbrAlphas.w;
+                if (toonPbrRampIntensity != rhs.toonPbrRampIntensity) return toonPbrRampIntensity < rhs.toonPbrRampIntensity;
                 if (shadingMode != rhs.shadingMode) return shadingMode < rhs.shadingMode;
                 if (useTexture != rhs.useTexture) return useTexture < rhs.useTexture;
                 if (enableNormalMap != rhs.enableNormalMap) return enableNormalMap < rhs.enableNormalMap;
@@ -150,6 +152,7 @@ namespace Alice
             if (a.toonPbrAlphas.y != b.toonPbrAlphas.y) return false;
             if (a.toonPbrAlphas.z != b.toonPbrAlphas.z) return false;
             if (a.toonPbrAlphas.w != b.toonPbrAlphas.w) return false;
+            if (a.toonPbrRampIntensity != b.toonPbrRampIntensity) return false;
             if (a.shadingMode != b.shadingMode) return false;
             if (a.useTexture != b.useTexture) return false;
             if (a.enableNormalMap != b.enableNormalMap) return false;
@@ -954,6 +957,7 @@ namespace Alice
                                                 const XMFLOAT4& toonPbrCuts,
                                                 const XMFLOAT4& toonPbrLevels,
                                                 const XMFLOAT4& toonPbrAlphas,
+                                                float toonPbrRampIntensity,
                                                 float envDiffuseStrength,
                                                 float envSpecularStrength,
                                                 const XMFLOAT3& outlineColor,
@@ -976,6 +980,7 @@ namespace Alice
         data.toonPbrCuts = toonPbrCuts;
         data.toonPbrLevels = toonPbrLevels;
         data.toonPbrAlphas = toonPbrAlphas;
+        data.toonPbrRampIntensity = toonPbrRampIntensity;
         data.envDiffuseStrength = envDiffuseStrength;
         data.envSpecularStrength = envSpecularStrength;
         data.outlineColor  = outlineColor;
@@ -1059,6 +1064,22 @@ namespace Alice
         m_context->UpdateSubresource(m_cbLighting.Get(), 0, nullptr, &data, 0, 0);
         m_context->VSSetConstantBuffers(1, 1, m_cbLighting.GetAddressOf());
         m_context->PSSetConstantBuffers(1, 1, m_cbLighting.GetAddressOf());
+    }
+
+    void ForwardRenderSystem::ApplyShadowSettings(const ShadowSettings& settings)
+    {
+        ShadowSettings clamped = settings;
+        clamped.mapSizePx = (std::max)(256u, clamped.mapSizePx);
+        clamped.pcfRadius = std::clamp(clamped.pcfRadius, 0.0f, 3.0f);
+
+        const bool sizeChanged = (clamped.mapSizePx != m_shadowSettings.mapSizePx);
+        m_shadowSettings = clamped;
+
+        if (sizeChanged && m_device)
+        {
+            // 해상도 변경 시 리소스 재생성
+            CreateShadowMapResources();
+        }
     }
 
     void ForwardRenderSystem::UpdateExtraLightsCB(const World& world)
@@ -1334,6 +1355,7 @@ namespace Alice
                 key.toonPbrCuts = cmd.toonPbrCuts;
                 key.toonPbrLevels = cmd.toonPbrLevels;
                 key.toonPbrAlphas = cmd.toonPbrAlphas;
+                key.toonPbrRampIntensity = cmd.toonPbrRampIntensity;
                 key.shadingMode = objectShadingMode;
                 key.useTexture = 1;
                 key.enableNormalMap = (norm != nullptr) ? 1 : 0;
@@ -1377,7 +1399,7 @@ namespace Alice
                                           batchKey.color, batchKey.roughness, batchKey.metalness, batchKey.ambientOcclusion,
                                           true, (batchKey.enableNormalMap != 0),
                                           batchKey.shadingMode, batchKey.normalStrength,
-                                          batchKey.toonPbrCuts, batchKey.toonPbrLevels, batchKey.toonPbrAlphas,
+                                          batchKey.toonPbrCuts, batchKey.toonPbrLevels, batchKey.toonPbrAlphas, batchKey.toonPbrRampIntensity,
                                           batchKey.envDiffuseStrength, batchKey.envSpecularStrength,
                                           XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
 
@@ -1441,7 +1463,7 @@ namespace Alice
                                       batchKey.color, batchKey.roughness, batchKey.metalness, batchKey.ambientOcclusion,
                                       true, (batchKey.enableNormalMap != 0),
                                       batchKey.shadingMode, batchKey.normalStrength,
-                                      batchKey.toonPbrCuts, batchKey.toonPbrLevels, batchKey.toonPbrAlphas,
+                                      batchKey.toonPbrCuts, batchKey.toonPbrLevels, batchKey.toonPbrAlphas, batchKey.toonPbrRampIntensity,
                                       batchKey.envDiffuseStrength, batchKey.envSpecularStrength,
                                       XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
 
@@ -1488,7 +1510,7 @@ namespace Alice
                     // [Pass 1] 원본
                     UpdatePerObjectCB(cmd.world, view, proj,
                         XMFLOAT4(cmd.color.x, cmd.color.y, cmd.color.z, cmd.alpha), r, m, ao, true, (m_flatNormalSRV != nullptr),
-                        objectShadingMode, cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas,
+                        objectShadingMode, cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas, cmd.toonPbrRampIntensity,
                         cmd.envDiffuseStrength, cmd.envSpecularStrength,
                         outlineColor, 0.0f);
                     m_context->DrawIndexed(sub.indexCount, sub.startIndex, cmd.baseVertex);
@@ -1499,7 +1521,7 @@ namespace Alice
                         m_context->RSSetState(m_rsCullFront.Get());
                         UpdatePerObjectCB(cmd.world, view, proj,
                             XMFLOAT4(cmd.color.x, cmd.color.y, cmd.color.z, cmd.alpha), r, m, ao, true, (m_flatNormalSRV != nullptr),
-                            objectShadingMode, cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas,
+                            objectShadingMode, cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas, cmd.toonPbrRampIntensity,
                             cmd.envDiffuseStrength, cmd.envSpecularStrength,
                             outlineColor, outlineWidth);
                         m_context->DrawIndexed(sub.indexCount, sub.startIndex, cmd.baseVertex);
@@ -1520,7 +1542,7 @@ namespace Alice
                 // [Pass 1] 원본
                 UpdatePerObjectCB(cmd.world, view, proj,
                     XMFLOAT4(cmd.color.x, cmd.color.y, cmd.color.z, cmd.alpha), r, m, ao, true, (m_flatNormalSRV != nullptr),
-                    objectShadingMode, cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas,
+                    objectShadingMode, cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas, cmd.toonPbrRampIntensity,
                     cmd.envDiffuseStrength, cmd.envSpecularStrength,
                     outlineColor, 0.0f);
                 m_context->DrawIndexed(cmd.indexCount, cmd.startIndex, cmd.baseVertex);
@@ -1531,7 +1553,7 @@ namespace Alice
                     m_context->RSSetState(m_rsCullFront.Get());
                     UpdatePerObjectCB(cmd.world, view, proj,
                         XMFLOAT4(cmd.color.x, cmd.color.y, cmd.color.z, cmd.alpha), r, m, ao, true, (m_flatNormalSRV != nullptr),
-                        objectShadingMode, cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas,
+                        objectShadingMode, cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas, cmd.toonPbrRampIntensity,
                         cmd.envDiffuseStrength, cmd.envSpecularStrength,
                         outlineColor, outlineWidth);
                     m_context->DrawIndexed(cmd.indexCount, cmd.startIndex, cmd.baseVertex);
@@ -1579,7 +1601,7 @@ namespace Alice
                                   batchKey.color, batchKey.roughness, batchKey.metalness, batchKey.ambientOcclusion,
                                   true, (batchKey.enableNormalMap != 0),
                                   batchKey.shadingMode, batchKey.normalStrength,
-                                  batchKey.toonPbrCuts, batchKey.toonPbrLevels, batchKey.toonPbrAlphas,
+                                  batchKey.toonPbrCuts, batchKey.toonPbrLevels, batchKey.toonPbrAlphas, batchKey.toonPbrRampIntensity,
                                   batchKey.envDiffuseStrength, batchKey.envSpecularStrength,
                                   XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
 
@@ -1774,7 +1796,7 @@ namespace Alice
                 XMFLOAT4 dummy(1, 1, 1, 1);
                 UpdatePerObjectCB(worldM, lightView, lightProj, dummy, 1, 0, 1.0f, false, false, 0,
                                   1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(), DefaultToonPbrAlphas(),
-                                  1.0f, 1.0f,
+                                  0.0f, 1.0f, 1.0f,
                                   XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
                 //m_context->DrawIndexed(m_indexCount, 0, 0);
             }
@@ -1847,7 +1869,7 @@ namespace Alice
                     XMFLOAT4 dummy(1, 1, 1, 1);
                     UpdatePerObjectCB(cmd.world, lightView, lightProj, dummy, 1, 0, 1.0f, false, false, 0,
                                       1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(), DefaultToonPbrAlphas(),
-                                      1.0f, 1.0f,
+                                      0.0f, 1.0f, 1.0f,
                                       XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
                     m_context->DrawIndexed(cmd.indexCount, cmd.startIndex, cmd.baseVertex);
                 }
@@ -1891,7 +1913,7 @@ namespace Alice
                                     XMFLOAT4 dummy(1, 1, 1, 1);
                                     UpdatePerObjectCB(DirectX::XMMatrixIdentity(), lightView, lightProj, dummy, 1, 0, 1.0f, false, false, 0,
                                                       1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(), DefaultToonPbrAlphas(),
-                                                      1.0f, 1.0f,
+                                                      0.0f, 1.0f, 1.0f,
                                                       XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
                                     m_context->DrawIndexedInstanced(currentKey.indexCount, (UINT)batchInstances.size(), currentKey.startIndex, currentKey.baseVertex, 0);
                                 }
@@ -1921,7 +1943,7 @@ namespace Alice
                             XMFLOAT4 dummy(1, 1, 1, 1);
                             UpdatePerObjectCB(DirectX::XMMatrixIdentity(), lightView, lightProj, dummy, 1, 0, 1.0f, false, false, 0,
                                               1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(), DefaultToonPbrAlphas(),
-                                              1.0f, 1.0f,
+                                              0.0f, 1.0f, 1.0f,
                                               XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
                             m_context->DrawIndexedInstanced(currentKey.indexCount, (UINT)batchInstances.size(), currentKey.startIndex, currentKey.baseVertex, 0);
                         }
@@ -2018,6 +2040,7 @@ namespace Alice
             XMFLOAT4 toonCuts = DefaultToonPbrCuts();
             XMFLOAT4 toonLevels = DefaultToonPbrLevels();
             XMFLOAT4 toonAlphas = DefaultToonPbrAlphas();
+            float toonRampIntensity = 0.0f;
 
             if (mat) {
                 color = { mat->color.x, mat->color.y, mat->color.z, mat->alpha };
@@ -2031,6 +2054,7 @@ namespace Alice
                 toonLevels = XMFLOAT4(mat->toonPbrLevel1, mat->toonPbrLevel2, mat->toonPbrLevel3,
                     mat->toonPbrBlur ? 1.0f : 0.0f);
                 toonAlphas = XMFLOAT4(mat->toonPbrLevel1Alpha, mat->toonPbrLevel2Alpha, mat->toonPbrLevel3Alpha, mat->shadowStrength);
+                toonRampIntensity = mat->toonPbrRampIntensity;
                 useTex = !mat->albedoTexturePath.empty();
             }
             const int objectShadingMode = (mat && mat->shadingMode >= 0) ? mat->shadingMode : shadingMode;
@@ -2062,7 +2086,7 @@ namespace Alice
             
             // [Pass 1] 원본 물체 그리기 (아웃라인 두께 0으로 강제)
             UpdatePerObjectCB(worldM, viewM, projM, color, rough, metal, ao, useTex, useNormalMap,
-                              objectShadingMode, normalStrength, toonCuts, toonLevels, toonAlphas,
+                              objectShadingMode, normalStrength, toonCuts, toonLevels, toonAlphas, toonRampIntensity,
                               envDiffuseStrength, envSpecularStrength,
                               outlineColor, 0.0f);
             m_context->DrawIndexed(m_indexCount, 0, 0);
@@ -2074,7 +2098,7 @@ namespace Alice
                 
                 // 아웃라인 값 적용
                 UpdatePerObjectCB(worldM, viewM, projM, color, rough, metal, ao, useTex, useNormalMap,
-                                  objectShadingMode, normalStrength, toonCuts, toonLevels, toonAlphas,
+                                  objectShadingMode, normalStrength, toonCuts, toonLevels, toonAlphas, toonRampIntensity,
                                   envDiffuseStrength, envSpecularStrength,
                                   outlineColor, outlineWidth);
                 m_context->DrawIndexed(m_indexCount, 0, 0);

--- a/Engine/src/Runtime/Rendering/ForwardRenderSystem.cpp
+++ b/Engine/src/Runtime/Rendering/ForwardRenderSystem.cpp
@@ -71,6 +71,7 @@ namespace Alice
             DirectX::XMFLOAT4 toonPbrLevels { 0.1f, 0.4f, 0.7f, 0.0f };
             DirectX::XMFLOAT4 toonPbrAlphas { 1.0f, 1.0f, 1.0f, 0.0f };
             float toonPbrRampIntensity = 0.0f;
+            float toonSelfShadowStrength = 1.0f;
             int shadingMode = 0;
             int useTexture = 0;
             int enableNormalMap = 0;
@@ -111,6 +112,7 @@ namespace Alice
                 if (toonPbrAlphas.z != rhs.toonPbrAlphas.z) return toonPbrAlphas.z < rhs.toonPbrAlphas.z;
                 if (toonPbrAlphas.w != rhs.toonPbrAlphas.w) return toonPbrAlphas.w < rhs.toonPbrAlphas.w;
                 if (toonPbrRampIntensity != rhs.toonPbrRampIntensity) return toonPbrRampIntensity < rhs.toonPbrRampIntensity;
+                if (toonSelfShadowStrength != rhs.toonSelfShadowStrength) return toonSelfShadowStrength < rhs.toonSelfShadowStrength;
                 if (shadingMode != rhs.shadingMode) return shadingMode < rhs.shadingMode;
                 if (useTexture != rhs.useTexture) return useTexture < rhs.useTexture;
                 if (enableNormalMap != rhs.enableNormalMap) return enableNormalMap < rhs.enableNormalMap;
@@ -153,6 +155,7 @@ namespace Alice
             if (a.toonPbrAlphas.z != b.toonPbrAlphas.z) return false;
             if (a.toonPbrAlphas.w != b.toonPbrAlphas.w) return false;
             if (a.toonPbrRampIntensity != b.toonPbrRampIntensity) return false;
+            if (a.toonSelfShadowStrength != b.toonSelfShadowStrength) return false;
             if (a.shadingMode != b.shadingMode) return false;
             if (a.useTexture != b.useTexture) return false;
             if (a.enableNormalMap != b.enableNormalMap) return false;
@@ -958,6 +961,7 @@ namespace Alice
                                                 const XMFLOAT4& toonPbrLevels,
                                                 const XMFLOAT4& toonPbrAlphas,
                                                 float toonPbrRampIntensity,
+                                                float toonSelfShadowStrength,
                                                 float envDiffuseStrength,
                                                 float envSpecularStrength,
                                                 const XMFLOAT3& outlineColor,
@@ -981,6 +985,7 @@ namespace Alice
         data.toonPbrLevels = toonPbrLevels;
         data.toonPbrAlphas = toonPbrAlphas;
         data.toonPbrRampIntensity = toonPbrRampIntensity;
+        data.toonSelfShadowStrength = toonSelfShadowStrength;
         data.envDiffuseStrength = envDiffuseStrength;
         data.envSpecularStrength = envSpecularStrength;
         data.outlineColor  = outlineColor;
@@ -1356,6 +1361,7 @@ namespace Alice
                 key.toonPbrLevels = cmd.toonPbrLevels;
                 key.toonPbrAlphas = cmd.toonPbrAlphas;
                 key.toonPbrRampIntensity = cmd.toonPbrRampIntensity;
+                key.toonSelfShadowStrength = cmd.toonSelfShadowStrength;
                 key.shadingMode = objectShadingMode;
                 key.useTexture = 1;
                 key.enableNormalMap = (norm != nullptr) ? 1 : 0;
@@ -1399,7 +1405,7 @@ namespace Alice
                                           batchKey.color, batchKey.roughness, batchKey.metalness, batchKey.ambientOcclusion,
                                           true, (batchKey.enableNormalMap != 0),
                                           batchKey.shadingMode, batchKey.normalStrength,
-                                          batchKey.toonPbrCuts, batchKey.toonPbrLevels, batchKey.toonPbrAlphas, batchKey.toonPbrRampIntensity,
+                                          batchKey.toonPbrCuts, batchKey.toonPbrLevels, batchKey.toonPbrAlphas, batchKey.toonPbrRampIntensity, batchKey.toonSelfShadowStrength,
                                           batchKey.envDiffuseStrength, batchKey.envSpecularStrength,
                                           XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
 
@@ -1463,7 +1469,7 @@ namespace Alice
                                       batchKey.color, batchKey.roughness, batchKey.metalness, batchKey.ambientOcclusion,
                                       true, (batchKey.enableNormalMap != 0),
                                       batchKey.shadingMode, batchKey.normalStrength,
-                                      batchKey.toonPbrCuts, batchKey.toonPbrLevels, batchKey.toonPbrAlphas, batchKey.toonPbrRampIntensity,
+                                      batchKey.toonPbrCuts, batchKey.toonPbrLevels, batchKey.toonPbrAlphas, batchKey.toonPbrRampIntensity, batchKey.toonSelfShadowStrength,
                                       batchKey.envDiffuseStrength, batchKey.envSpecularStrength,
                                       XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
 
@@ -1510,7 +1516,7 @@ namespace Alice
                     // [Pass 1] 원본
                     UpdatePerObjectCB(cmd.world, view, proj,
                         XMFLOAT4(cmd.color.x, cmd.color.y, cmd.color.z, cmd.alpha), r, m, ao, true, (m_flatNormalSRV != nullptr),
-                        objectShadingMode, cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas, cmd.toonPbrRampIntensity,
+                        objectShadingMode, cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas, cmd.toonPbrRampIntensity, cmd.toonSelfShadowStrength,
                         cmd.envDiffuseStrength, cmd.envSpecularStrength,
                         outlineColor, 0.0f);
                     m_context->DrawIndexed(sub.indexCount, sub.startIndex, cmd.baseVertex);
@@ -1521,7 +1527,7 @@ namespace Alice
                         m_context->RSSetState(m_rsCullFront.Get());
                         UpdatePerObjectCB(cmd.world, view, proj,
                             XMFLOAT4(cmd.color.x, cmd.color.y, cmd.color.z, cmd.alpha), r, m, ao, true, (m_flatNormalSRV != nullptr),
-                            objectShadingMode, cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas, cmd.toonPbrRampIntensity,
+                            objectShadingMode, cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas, cmd.toonPbrRampIntensity, cmd.toonSelfShadowStrength,
                             cmd.envDiffuseStrength, cmd.envSpecularStrength,
                             outlineColor, outlineWidth);
                         m_context->DrawIndexed(sub.indexCount, sub.startIndex, cmd.baseVertex);
@@ -1542,7 +1548,7 @@ namespace Alice
                 // [Pass 1] 원본
                 UpdatePerObjectCB(cmd.world, view, proj,
                     XMFLOAT4(cmd.color.x, cmd.color.y, cmd.color.z, cmd.alpha), r, m, ao, true, (m_flatNormalSRV != nullptr),
-                    objectShadingMode, cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas, cmd.toonPbrRampIntensity,
+                    objectShadingMode, cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas, cmd.toonPbrRampIntensity, cmd.toonSelfShadowStrength,
                     cmd.envDiffuseStrength, cmd.envSpecularStrength,
                     outlineColor, 0.0f);
                 m_context->DrawIndexed(cmd.indexCount, cmd.startIndex, cmd.baseVertex);
@@ -1553,7 +1559,7 @@ namespace Alice
                     m_context->RSSetState(m_rsCullFront.Get());
                     UpdatePerObjectCB(cmd.world, view, proj,
                         XMFLOAT4(cmd.color.x, cmd.color.y, cmd.color.z, cmd.alpha), r, m, ao, true, (m_flatNormalSRV != nullptr),
-                        objectShadingMode, cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas, cmd.toonPbrRampIntensity,
+                        objectShadingMode, cmd.normalStrength, cmd.toonPbrCuts, cmd.toonPbrLevels, cmd.toonPbrAlphas, cmd.toonPbrRampIntensity, cmd.toonSelfShadowStrength,
                         cmd.envDiffuseStrength, cmd.envSpecularStrength,
                         outlineColor, outlineWidth);
                     m_context->DrawIndexed(cmd.indexCount, cmd.startIndex, cmd.baseVertex);
@@ -1601,7 +1607,7 @@ namespace Alice
                                   batchKey.color, batchKey.roughness, batchKey.metalness, batchKey.ambientOcclusion,
                                   true, (batchKey.enableNormalMap != 0),
                                   batchKey.shadingMode, batchKey.normalStrength,
-                                  batchKey.toonPbrCuts, batchKey.toonPbrLevels, batchKey.toonPbrAlphas, batchKey.toonPbrRampIntensity,
+                                  batchKey.toonPbrCuts, batchKey.toonPbrLevels, batchKey.toonPbrAlphas, batchKey.toonPbrRampIntensity, batchKey.toonSelfShadowStrength,
                                   batchKey.envDiffuseStrength, batchKey.envSpecularStrength,
                                   XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
 
@@ -1796,7 +1802,7 @@ namespace Alice
                 XMFLOAT4 dummy(1, 1, 1, 1);
                 UpdatePerObjectCB(worldM, lightView, lightProj, dummy, 1, 0, 1.0f, false, false, 0,
                                   1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(), DefaultToonPbrAlphas(),
-                                  0.0f, 1.0f, 1.0f,
+                                  0.0f, 1.0f, 1.0f, 1.0f,
                                   XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
                 //m_context->DrawIndexed(m_indexCount, 0, 0);
             }
@@ -1869,7 +1875,7 @@ namespace Alice
                     XMFLOAT4 dummy(1, 1, 1, 1);
                     UpdatePerObjectCB(cmd.world, lightView, lightProj, dummy, 1, 0, 1.0f, false, false, 0,
                                       1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(), DefaultToonPbrAlphas(),
-                                      0.0f, 1.0f, 1.0f,
+                                      0.0f, 1.0f, 1.0f, 1.0f,
                                       XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
                     m_context->DrawIndexed(cmd.indexCount, cmd.startIndex, cmd.baseVertex);
                 }
@@ -1913,7 +1919,7 @@ namespace Alice
                                     XMFLOAT4 dummy(1, 1, 1, 1);
                                     UpdatePerObjectCB(DirectX::XMMatrixIdentity(), lightView, lightProj, dummy, 1, 0, 1.0f, false, false, 0,
                                                       1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(), DefaultToonPbrAlphas(),
-                                                      0.0f, 1.0f, 1.0f,
+                                                      0.0f, 1.0f, 1.0f, 1.0f,
                                                       XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
                                     m_context->DrawIndexedInstanced(currentKey.indexCount, (UINT)batchInstances.size(), currentKey.startIndex, currentKey.baseVertex, 0);
                                 }
@@ -1943,7 +1949,7 @@ namespace Alice
                             XMFLOAT4 dummy(1, 1, 1, 1);
                             UpdatePerObjectCB(DirectX::XMMatrixIdentity(), lightView, lightProj, dummy, 1, 0, 1.0f, false, false, 0,
                                               1.0f, DefaultToonPbrCuts(), DefaultToonPbrLevels(), DefaultToonPbrAlphas(),
-                                              0.0f, 1.0f, 1.0f,
+                                              0.0f, 1.0f, 1.0f, 1.0f,
                                               XMFLOAT3(0.0f, 0.0f, 0.0f), 0.0f);
                             m_context->DrawIndexedInstanced(currentKey.indexCount, (UINT)batchInstances.size(), currentKey.startIndex, currentKey.baseVertex, 0);
                         }
@@ -2041,6 +2047,7 @@ namespace Alice
             XMFLOAT4 toonLevels = DefaultToonPbrLevels();
             XMFLOAT4 toonAlphas = DefaultToonPbrAlphas();
             float toonRampIntensity = 0.0f;
+            float toonSelfShadowStrength = 1.0f;
 
             if (mat) {
                 color = { mat->color.x, mat->color.y, mat->color.z, mat->alpha };
@@ -2055,6 +2062,7 @@ namespace Alice
                     mat->toonPbrBlur ? 1.0f : 0.0f);
                 toonAlphas = XMFLOAT4(mat->toonPbrLevel1Alpha, mat->toonPbrLevel2Alpha, mat->toonPbrLevel3Alpha, mat->shadowStrength);
                 toonRampIntensity = mat->toonPbrRampIntensity;
+                toonSelfShadowStrength = mat->toonSelfShadowStrength;
                 useTex = !mat->albedoTexturePath.empty();
             }
             const int objectShadingMode = (mat && mat->shadingMode >= 0) ? mat->shadingMode : shadingMode;
@@ -2086,7 +2094,7 @@ namespace Alice
             
             // [Pass 1] 원본 물체 그리기 (아웃라인 두께 0으로 강제)
             UpdatePerObjectCB(worldM, viewM, projM, color, rough, metal, ao, useTex, useNormalMap,
-                              objectShadingMode, normalStrength, toonCuts, toonLevels, toonAlphas, toonRampIntensity,
+                              objectShadingMode, normalStrength, toonCuts, toonLevels, toonAlphas, toonRampIntensity, toonSelfShadowStrength,
                               envDiffuseStrength, envSpecularStrength,
                               outlineColor, 0.0f);
             m_context->DrawIndexed(m_indexCount, 0, 0);
@@ -2098,7 +2106,7 @@ namespace Alice
                 
                 // 아웃라인 값 적용
                 UpdatePerObjectCB(worldM, viewM, projM, color, rough, metal, ao, useTex, useNormalMap,
-                                  objectShadingMode, normalStrength, toonCuts, toonLevels, toonAlphas, toonRampIntensity,
+                                  objectShadingMode, normalStrength, toonCuts, toonLevels, toonAlphas, toonRampIntensity, toonSelfShadowStrength,
                                   envDiffuseStrength, envSpecularStrength,
                                   outlineColor, outlineWidth);
                 m_context->DrawIndexed(m_indexCount, 0, 0);

--- a/Engine/src/Runtime/Rendering/ForwardRenderSystem.cpp
+++ b/Engine/src/Runtime/Rendering/ForwardRenderSystem.cpp
@@ -8,6 +8,7 @@
 #include <DirectXTK/DDSTextureLoader.h>
 #include <filesystem>
 #include <vector>
+#include <cstdint>
 #include <cmath>
 #include <cfloat>
 #include <algorithm>
@@ -47,6 +48,109 @@ namespace Alice
                 }
             }
             return {};
+        }
+
+        static bool IsDDSHeader(const std::vector<std::uint8_t>& data)
+        {
+            return data.size() >= 4 &&
+                   data[0] == 'D' &&
+                   data[1] == 'D' &&
+                   data[2] == 'S' &&
+                   data[3] == ' ';
+        }
+
+        static ComPtr<ID3D11ShaderResourceView> LoadColorTextureSRV(
+            ResourceManager* resources,
+            ID3D11Device* device,
+            const std::filesystem::path& logicalPath)
+        {
+            ComPtr<ID3D11ShaderResourceView> outSrv;
+            if (!resources || !device || logicalPath.empty())
+            {
+                return outSrv;
+            }
+
+            std::vector<std::uint8_t> data;
+            if (!resources->LoadBinaryAuto(logicalPath, data) || data.empty())
+            {
+                return outSrv;
+            }
+
+            HRESULT hr = E_FAIL;
+            if (IsDDSHeader(data))
+            {
+                constexpr auto kDdsFlags = DirectX::DDS_LOADER_FORCE_SRGB;
+                hr = DirectX::CreateDDSTextureFromMemoryEx(
+                    device,
+                    data.data(),
+                    data.size(),
+                    0,
+                    D3D11_USAGE_DEFAULT,
+                    D3D11_BIND_SHADER_RESOURCE,
+                    0,
+                    0,
+                    kDdsFlags,
+                    nullptr,
+                    outSrv.GetAddressOf());
+
+                if (FAILED(hr))
+                {
+                    hr = DirectX::CreateDDSTextureFromMemory(
+                        device,
+                        data.data(),
+                        data.size(),
+                        nullptr,
+                        outSrv.GetAddressOf());
+                }
+            }
+            else
+            {
+                ComPtr<ID3D11DeviceContext> ctx;
+                device->GetImmediateContext(ctx.GetAddressOf());
+                ComPtr<ID3D11Resource> res;
+
+                hr = DirectX::CreateWICTextureFromMemoryEx(
+                    device,
+                    ctx.Get(),
+                    data.data(),
+                    data.size(),
+                    0,
+                    D3D11_USAGE_DEFAULT,
+                    D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET,
+                    0,
+                    D3D11_RESOURCE_MISC_GENERATE_MIPS,
+                    DirectX::WIC_LOADER_FORCE_SRGB,
+                    res.GetAddressOf(),
+                    outSrv.GetAddressOf());
+
+                if (SUCCEEDED(hr) && ctx && outSrv)
+                {
+                    ctx->GenerateMips(outSrv.Get());
+                }
+                else if (FAILED(hr))
+                {
+                    hr = DirectX::CreateWICTextureFromMemoryEx(
+                        device,
+                        ctx.Get(),
+                        data.data(),
+                        data.size(),
+                        0,
+                        D3D11_USAGE_DEFAULT,
+                        D3D11_BIND_SHADER_RESOURCE,
+                        0,
+                        0,
+                        DirectX::WIC_LOADER_FORCE_SRGB,
+                        nullptr,
+                        outSrv.GetAddressOf());
+                }
+            }
+
+            if (FAILED(hr))
+            {
+                outSrv.Reset();
+            }
+
+            return outSrv;
         }
 
         // 인스턴싱 배치 키 (재질/메시 기준)
@@ -932,7 +1036,13 @@ namespace Alice
 
         if (!m_device || !m_resources) return nullptr;
 
-        auto srv = m_resources->LoadData<ID3D11ShaderResourceView>(std::filesystem::path(path), m_device.Get());
+        // Material albedo/decal 경로는 컬러 텍스처로 취급해 sRGB를 강제합니다.
+        auto srv = LoadColorTextureSRV(m_resources, m_device.Get(), std::filesystem::path(path));
+        if (!srv)
+        {
+            // 폴백: 기존 ResourceManager 경로
+            srv = m_resources->LoadData<ID3D11ShaderResourceView>(std::filesystem::path(path), m_device.Get());
+        }
 
         if (!srv)
         {

--- a/Engine/src/Runtime/Rendering/ForwardRenderSystem.cpp
+++ b/Engine/src/Runtime/Rendering/ForwardRenderSystem.cpp
@@ -1295,8 +1295,12 @@ namespace Alice
             bool isPositiveDet = XMVectorGetX(XMMatrixDeterminant(cmd.world)) >= 0.0f;
             m_context->RSSetState(isPositiveDet ? m_rasterizerStateReversed.Get() : m_rasterizerState.Get());
 
-            float r = (cmd.roughness != 0.0f) ? cmd.roughness : m_lightingParameters.roughness;
-            float m = (cmd.metalness != 0.0f) ? cmd.metalness : m_lightingParameters.metalness;
+            // NOTE:
+            // roughness/metalness에서 0.0은 유효한 아트 값입니다.
+            // 과거 "0이면 전역값 대체" 로직 때문에 metalness=0이어도 금속감이 남는 문제가 있어,
+            // 커맨드 값을 그대로 사용하고 범위만 안전하게 클램프합니다.
+            float r = std::clamp(cmd.roughness, 0.0f, 1.0f);
+            float m = std::clamp(cmd.metalness, 0.0f, 1.0f);
             float ao = (cmd.shadingMode >= 0) ? cmd.ambientOcclusion : m_lightingParameters.ambientOcclusion;
             const int objectShadingMode = (cmd.shadingMode >= 0) ? cmd.shadingMode : shadingMode;
             // 아웃라인 파라미터

--- a/Engine/src/Runtime/Rendering/ForwardRenderSystem.h
+++ b/Engine/src/Runtime/Rendering/ForwardRenderSystem.h
@@ -107,6 +107,7 @@ namespace Alice
                                float normalStrength,
                                const DirectX::XMFLOAT4& toonPbrCuts,
                                const DirectX::XMFLOAT4& toonPbrLevels,
+                               const DirectX::XMFLOAT4& toonPbrAlphas,
                                float envDiffuseStrength = 1.0f,
                                float envSpecularStrength = 1.0f,
                                const DirectX::XMFLOAT3& outlineColor = DirectX::XMFLOAT3(0.0f, 0.0f, 0.0f),

--- a/Engine/src/Runtime/Rendering/ForwardRenderSystem.h
+++ b/Engine/src/Runtime/Rendering/ForwardRenderSystem.h
@@ -108,6 +108,7 @@ namespace Alice
                                const DirectX::XMFLOAT4& toonPbrCuts,
                                const DirectX::XMFLOAT4& toonPbrLevels,
                                const DirectX::XMFLOAT4& toonPbrAlphas,
+                               float toonPbrRampIntensity,
                                float envDiffuseStrength = 1.0f,
                                float envSpecularStrength = 1.0f,
                                const DirectX::XMFLOAT3& outlineColor = DirectX::XMFLOAT3(0.0f, 0.0f, 0.0f),
@@ -302,6 +303,11 @@ namespace Alice
         /// ImGui 등에서 이 값을 직접 수정해도 됩니다.
         LightingParameters& GetLightingParameters() { return m_lightingParameters; }
         const LightingParameters& GetLightingParameters() const { return m_lightingParameters; }
+
+        /// Shadow 설정을 반환합니다.
+        const ShadowSettings& GetShadowSettings() const { return m_shadowSettings; }
+        /// Shadow 설정을 적용합니다. (해상도 변경 시 리소스를 재생성)
+        void ApplyShadowSettings(const ShadowSettings& settings);
 
         /// Game 창에서 사용할 씬 컬러 텍스처 SRV
         ID3D11ShaderResourceView* GetSceneColorSRV() const { return m_sceneSRV.Get(); }

--- a/Engine/src/Runtime/Rendering/ForwardRenderSystem.h
+++ b/Engine/src/Runtime/Rendering/ForwardRenderSystem.h
@@ -109,6 +109,7 @@ namespace Alice
                                const DirectX::XMFLOAT4& toonPbrLevels,
                                const DirectX::XMFLOAT4& toonPbrAlphas,
                                float toonPbrRampIntensity,
+                               float toonSelfShadowStrength,
                                float envDiffuseStrength = 1.0f,
                                float envSpecularStrength = 1.0f,
                                const DirectX::XMFLOAT3& outlineColor = DirectX::XMFLOAT3(0.0f, 0.0f, 0.0f),

--- a/Engine/src/Runtime/Rendering/RenderTypes.h
+++ b/Engine/src/Runtime/Rendering/RenderTypes.h
@@ -103,6 +103,8 @@ namespace Alice
         float             metalness    { 0.0f };                // 0.0 = 비금속, 1.0 = 금속
         float             roughness    { 0.5f };                // 0.0 = 거울, 1.0 = 거친 표면
         float             ambientOcclusion { 1.0f };            // AO (0.0 ~ 1.0)
+        float             shadowStrength { 1.0f };              // 전역 그림자 강도 (0~1)
+        float             toonShadowStrength { 1.0f };          // ToonPBREditable 전용 그림자 강도 (0~1)
 
         // 광원 세기
         float             keyIntensity  { 1.0f };
@@ -193,7 +195,7 @@ namespace Alice
         // ToonPBREditable 파라미터 (shadingMode == 7)
         DirectX::XMFLOAT4 toonPbrCuts   { 0.2f, 0.5f, 0.95f, 1.0f }; // cut1, cut2, cut3, strength
         DirectX::XMFLOAT4 toonPbrLevels { 0.1f, 0.4f, 0.7f, 0.0f };  // level1, level2, level3, blur(0/1)
-        DirectX::XMFLOAT4 toonPbrAlphas { 1.0f, 1.0f, 1.0f, 0.0f };  // level1~3 alpha, w unused
+        DirectX::XMFLOAT4 toonPbrAlphas { 1.0f, 1.0f, 1.0f, 1.0f };  // level1~3 alpha, w: shadowStrength
 
         // 선택적인 알베도 텍스처 경로 (.alice 단일 포맷 또는 원본 이미지 경로)
         std::string       albedoTexturePath;
@@ -396,7 +398,7 @@ namespace Alice
         // ToonPBREditable 파라미터
         DirectX::XMFLOAT4 toonPbrCuts;    // Offset: 256 -> 272
         DirectX::XMFLOAT4 toonPbrLevels;  // Offset: 272 -> 288 (w: blur)
-        DirectX::XMFLOAT4 toonPbrAlphas;  // Offset: 288 -> 304 (alpha1~3)
+        DirectX::XMFLOAT4 toonPbrAlphas;  // Offset: 288 -> 304 (alpha1~3, w: shadowStrength)
         
         // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
         DirectX::XMFLOAT3 outlineColor;  // 아웃라인 색상 (Offset: 304 -> 316)
@@ -434,5 +436,8 @@ namespace Alice
 		float             shadowMapSize;     // 섀도우맵 한 변(px)
 		float             shadowPcfRadius;   // PCF 반경(texel)
 		int               shadowEnabled;     // 0/1
+		float             shadowStrength;    // 전역 그림자 강도 (0~1)
+		float             toonShadowStrength; // ToonPBREditable 전용 그림자 강도 (0~1)
+		float             shadowPad[2];      // 16바이트 정렬
 	};
 }

--- a/Engine/src/Runtime/Rendering/RenderTypes.h
+++ b/Engine/src/Runtime/Rendering/RenderTypes.h
@@ -193,6 +193,7 @@ namespace Alice
         // ToonPBREditable 파라미터 (shadingMode == 7)
         DirectX::XMFLOAT4 toonPbrCuts   { 0.2f, 0.5f, 0.95f, 1.0f }; // cut1, cut2, cut3, strength
         DirectX::XMFLOAT4 toonPbrLevels { 0.1f, 0.4f, 0.7f, 0.0f };  // level1, level2, level3, blur(0/1)
+        DirectX::XMFLOAT4 toonPbrAlphas { 1.0f, 1.0f, 1.0f, 0.0f };  // level1~3 alpha, w unused
 
         // 선택적인 알베도 텍스처 경로 (.alice 단일 포맷 또는 원본 이미지 경로)
         std::string       albedoTexturePath;
@@ -395,10 +396,11 @@ namespace Alice
         // ToonPBREditable 파라미터
         DirectX::XMFLOAT4 toonPbrCuts;    // Offset: 256 -> 272
         DirectX::XMFLOAT4 toonPbrLevels;  // Offset: 272 -> 288 (w: blur)
+        DirectX::XMFLOAT4 toonPbrAlphas;  // Offset: 288 -> 304 (alpha1~3)
         
         // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
-        DirectX::XMFLOAT3 outlineColor;  // 아웃라인 색상 (Offset: 288 -> 300)
-        float             outlineWidth;  // 아웃라인 두께 (월드 단위) (Offset: 300 -> 304)
+        DirectX::XMFLOAT3 outlineColor;  // 아웃라인 색상 (Offset: 304 -> 316)
+        float             outlineWidth;  // 아웃라인 두께 (월드 단위) (Offset: 316 -> 320)
 	};
 
 	/// 단순 Directional Light 2개와 재질 파라미터를 담는 구조체입니다.

--- a/Engine/src/Runtime/Rendering/RenderTypes.h
+++ b/Engine/src/Runtime/Rendering/RenderTypes.h
@@ -94,7 +94,7 @@ namespace Alice
     struct LightingParameters
     {
         // 재질 색상/하이라이트 (레거시 쉐이더용)
-        DirectX::XMFLOAT3 diffuseColor  { 0.7f, 0.7f, 0.9f };
+        DirectX::XMFLOAT3 diffuseColor  { 1.0f, 1.0f, 1.0f };
         DirectX::XMFLOAT3 specularColor { 1.0f, 1.0f, 1.0f };
         float             shininess     { 32.0f };
 

--- a/Engine/src/Runtime/Rendering/RenderTypes.h
+++ b/Engine/src/Runtime/Rendering/RenderTypes.h
@@ -197,6 +197,7 @@ namespace Alice
         DirectX::XMFLOAT4 toonPbrLevels { 0.1f, 0.4f, 0.7f, 0.0f };  // level1, level2, level3, blur(0/1)
         DirectX::XMFLOAT4 toonPbrAlphas { 1.0f, 1.0f, 1.0f, 1.0f };  // level1~3 alpha, w: shadowStrength
         float             toonPbrRampIntensity { 0.0f };            // 0: 기존, 1: 가장 어두운 밴드 완화
+        float             toonSelfShadowStrength { 1.0f };          // 0: 셀프 음영 최소화, 1: 기존 Toon 셀프 음영
 
         // 선택적인 알베도 텍스처 경로 (.alice 단일 포맷 또는 원본 이미지 경로)
         std::string       albedoTexturePath;
@@ -401,10 +402,11 @@ namespace Alice
         DirectX::XMFLOAT4 toonPbrLevels;  // Offset: 272 -> 288 (w: blur)
         DirectX::XMFLOAT4 toonPbrAlphas;  // Offset: 288 -> 304 (alpha1~3, w: shadowStrength)
         float             toonPbrRampIntensity; // Offset: 304 -> 308
+        float             toonSelfShadowStrength; // Offset: 308 -> 312 (ToonPBREditable 셀프 음영 강도)
         
         // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
-        DirectX::XMFLOAT3 outlineColor;  // 아웃라인 색상 (Offset: 308 -> 320)
-        float             outlineWidth;  // 아웃라인 두께 (월드 단위) (Offset: 320 -> 324)
+        DirectX::XMFLOAT3 outlineColor;  // 아웃라인 색상 (Offset: 312 -> 324)
+        float             outlineWidth;  // 아웃라인 두께 (월드 단위) (Offset: 324 -> 328)
 	};
 
 	/// 단순 Directional Light 2개와 재질 파라미터를 담는 구조체입니다.

--- a/Engine/src/Runtime/Rendering/RenderTypes.h
+++ b/Engine/src/Runtime/Rendering/RenderTypes.h
@@ -196,6 +196,7 @@ namespace Alice
         DirectX::XMFLOAT4 toonPbrCuts   { 0.2f, 0.5f, 0.95f, 1.0f }; // cut1, cut2, cut3, strength
         DirectX::XMFLOAT4 toonPbrLevels { 0.1f, 0.4f, 0.7f, 0.0f };  // level1, level2, level3, blur(0/1)
         DirectX::XMFLOAT4 toonPbrAlphas { 1.0f, 1.0f, 1.0f, 1.0f };  // level1~3 alpha, w: shadowStrength
+        float             toonPbrRampIntensity { 0.0f };            // 0: 기존, 1: 가장 어두운 밴드 완화
 
         // 선택적인 알베도 텍스처 경로 (.alice 단일 포맷 또는 원본 이미지 경로)
         std::string       albedoTexturePath;
@@ -204,12 +205,12 @@ namespace Alice
     };
 
 
-    struct ShadowSettings
+	struct ShadowSettings
 	{
 		// 튜토리얼(34_ToneMapping)과 동일한 기본값 스케일
-		std::uint32_t mapSizePx = 2048;   // 섀도우맵 해상도(한 변)
+		std::uint32_t mapSizePx = 4096;   // 섀도우맵 해상도(한 변)
 		float         bias = 0.0015f;
-		float         pcfRadius = 1.0f;   // texel 단위(0~3 권장)
+		float         pcfRadius = 0.5f;   // texel 단위(0~3 권장)
 		float         orthoRadius = 20.0f; // 월드 단위(씬 크기에 맞게 조절)
 		bool          enabled = true;
 	};
@@ -399,10 +400,11 @@ namespace Alice
         DirectX::XMFLOAT4 toonPbrCuts;    // Offset: 256 -> 272
         DirectX::XMFLOAT4 toonPbrLevels;  // Offset: 272 -> 288 (w: blur)
         DirectX::XMFLOAT4 toonPbrAlphas;  // Offset: 288 -> 304 (alpha1~3, w: shadowStrength)
+        float             toonPbrRampIntensity; // Offset: 304 -> 308
         
         // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
-        DirectX::XMFLOAT3 outlineColor;  // 아웃라인 색상 (Offset: 304 -> 316)
-        float             outlineWidth;  // 아웃라인 두께 (월드 단위) (Offset: 316 -> 320)
+        DirectX::XMFLOAT3 outlineColor;  // 아웃라인 색상 (Offset: 308 -> 320)
+        float             outlineWidth;  // 아웃라인 두께 (월드 단위) (Offset: 320 -> 324)
 	};
 
 	/// 단순 Directional Light 2개와 재질 파라미터를 담는 구조체입니다.

--- a/Engine/src/Runtime/Rendering/ShaderCode/DeferredShader.h
+++ b/Engine/src/Runtime/Rendering/ShaderCode/DeferredShader.h
@@ -1228,7 +1228,17 @@ float4 main(PS_INPUT_QUAD pIn) : SV_Target
     diffuseIBL *= envDiffuseStrength;
     specularIBL *= envSpecularStrength;
 
-    float3 iblColor = (diffuseIBL + specularIBL) * ao;
+    float shadowIBLDiffuse = lerp(0.35f, 1.0f, shadowVis);
+    float shadowIBLSpecular = 1.0f;
+    if (toonEditable)
+    {
+        // ToonPBREditable은 외부 물체 그림자 안에서 밝기 변화가 분명히 보이도록
+        // IBL까지 shadowVis를 적용합니다.
+        shadowIBLDiffuse = shadowVis;
+        shadowIBLSpecular = lerp(0.25f, 1.0f, shadowVis);
+    }
+
+    float3 iblColor = (diffuseIBL * shadowIBLDiffuse + specularIBL * shadowIBLSpecular) * ao;
 
     // 최종 색상 계산
     float3 color = directLighting + extraLighting + iblColor;

--- a/Engine/src/Runtime/Rendering/ShaderCode/DeferredShader.h
+++ b/Engine/src/Runtime/Rendering/ShaderCode/DeferredShader.h
@@ -1135,7 +1135,12 @@ float4 main(PS_INPUT_QUAD pIn) : SV_Target
     float3 kD = (1.0f - kS_IBL) * (1.0f - metalness);
     
     // Direct Light (Directional + Extra Lights)
-    float3 lightColorDir = g_LightColor.rgb * g_intensity * PI;
+    // NOTE:
+    // - EvaluatePBRLight 내부에서 diffuse는 INV_PI를 사용하므로
+    //   여기서 추가 PI를 곱하면 specular가 상대적으로 과증폭되어
+    //   metalness=0에서도 과도한 금속광처럼 보일 수 있습니다.
+    // - Forward 경로와 일치하도록 light 세기는 intensity 그대로 사용합니다.
+    float3 lightColorDir = g_LightColor.rgb * g_intensity;
     float3 directLighting = 0.0f;
     {
         float3 lit = EvaluatePBRLight(N, V, L, albedoPBR, metalness, roughness, lightColorDir);
@@ -1158,7 +1163,7 @@ float4 main(PS_INPUT_QUAD pIn) : SV_Target
         float dist = length(toLight);
         float3 Lp = (dist > 0.0001f) ? (toLight / dist) : float3(0, 0, 1);
         float atten = ComputeAttenuation(dist, pl.range);
-        float3 lc = pl.color * pl.intensity * atten * PI;
+        float3 lc = pl.color * pl.intensity * atten;
         float3 lit = EvaluatePBRLight(N, V, Lp, albedoPBR, metalness, roughness, lc);
         float ndotl = max(dot(N, Lp), 0.0f);
         if (toonPbr && ndotl > 0.0f)
@@ -1178,7 +1183,7 @@ float4 main(PS_INPUT_QUAD pIn) : SV_Target
         float3 Ls = (dist > 0.0001f) ? (toLight / dist) : float3(0, 0, 1);
         float atten = ComputeAttenuation(dist, sl.range);
         float spot = ComputeSpotFactor(Ls, sl.direction, sl.innerCos, sl.outerCos);
-        float3 lc = sl.color * sl.intensity * atten * spot * PI;
+        float3 lc = sl.color * sl.intensity * atten * spot;
         float3 lit = EvaluatePBRLight(N, V, Ls, albedoPBR, metalness, roughness, lc);
         float ndotl = max(dot(N, Ls), 0.0f);
         if (toonPbr && ndotl > 0.0f)
@@ -1199,7 +1204,7 @@ float4 main(PS_INPUT_QUAD pIn) : SV_Target
         float atten = ComputeAttenuation(dist, rl.range);
         float facing = ComputeRectFactor(Lr, rl.direction);
         float areaScale = max(rl.width * rl.height, 0.01f);
-        float3 lc = rl.color * rl.intensity * atten * facing * areaScale * PI;
+        float3 lc = rl.color * rl.intensity * atten * facing * areaScale;
         float3 lit = EvaluatePBRLight(N, V, Lr, albedoPBR, metalness, roughness, lc);
         float ndotl = max(dot(N, Lr), 0.0f);
         if (toonPbr && ndotl > 0.0f)
@@ -1689,7 +1694,7 @@ float4 main(PSIn pIn) : SV_Target
     float3 kD = (1.0f - kS) * (1.0f - metalness);
     float3 diffuse = kD * albedoLinear * INV_PI;
 
-    float3 radiance = g_LightColor.rgb * PI * g_LightIntensity;
+    float3 radiance = g_LightColor.rgb * g_LightIntensity;
     float3 direct = (diffuse + specular) * radiance * NdotL * ao;
 
     const bool toonPbr = (gShadingMode == 5 || gShadingMode == 7);

--- a/Engine/src/Runtime/Rendering/ShaderCode/DeferredShader.h
+++ b/Engine/src/Runtime/Rendering/ShaderCode/DeferredShader.h
@@ -527,7 +527,7 @@ GBufferOut main(VertexOut pIn)
     {
         gOut.ToonParams = float4(saturate(gEnvDiffuseStrength), saturate(gEnvSpecularStrength), 0.0f, 0.0f);
     }
-    gOut.ToonAlphas = float4(saturate(gToonPbrAlphas.xyz), 1.0f);
+    gOut.ToonAlphas = float4(saturate(gToonPbrAlphas.xyz), saturate(gToonPbrAlphas.w));
     // shadingMode + AO를 [0,1] 범위로 인코딩하여 저장
     gOut.BaseColor  = float4(baseColor, saturate(shadingEncoded));
     
@@ -729,7 +729,9 @@ cbuffer ShadowCB : register(b4)
     float    g_ShadowMapSize2;
     float    g_ShadowPCFRadius2;
     int      g_ShadowEnabled2;
-    float3   g_ShadowPad2;
+    float    g_ShadowStrength2;
+    float    g_ToonShadowStrength2;
+    float2   g_ShadowPad2;
 };
 
 // 그림자 계산 함수 (PCF)
@@ -968,7 +970,9 @@ float4 main(PS_INPUT_QUAD pIn) : SV_Target
     float4 metalness_packed = g_Metalness.Sample(g_Sam, pIn.uv);
     float4 baseColor = g_BaseColor.Sample(g_Sam, pIn.uv);
     float4 toonParams = g_ToonParams.Sample(g_Sam, pIn.uv);
-    float3 toonAlphas = g_ToonAlphas.Sample(g_Sam, pIn.uv).rgb;
+    float4 toonAlphasSample = g_ToonAlphas.Sample(g_Sam, pIn.uv);
+    float3 toonAlphas = toonAlphasSample.rgb;
+    float  materialShadowStrength = toonAlphasSample.a;
     float4 decalAlbedo = g_DecalAlbedo.Sample(g_Sam, pIn.uv);
     float depth = g_SceneDepth.Sample(g_Sam, pIn.uv);
     
@@ -1036,6 +1040,12 @@ float4 main(PS_INPUT_QUAD pIn) : SV_Target
     }
 
     float shadowVis = CalcShadowFactorDeferred(posW, g_ShadowMap, g_ShadowSampler);
+    float shadowStrength = saturate(g_ShadowStrength2) * saturate(materialShadowStrength);
+    if (toonEditable)
+    {
+        shadowStrength *= saturate(g_ToonShadowStrength2);
+    }
+    shadowVis = lerp(1.0f, shadowVis, shadowStrength);
 
     if (!usePbr)
     {

--- a/Engine/src/Runtime/Rendering/ShaderCode/DeferredShader.h
+++ b/Engine/src/Runtime/Rendering/ShaderCode/DeferredShader.h
@@ -32,6 +32,7 @@ cbuffer CBPerObject : register(b0)
 
     float4   gToonPbrCuts;
     float4   gToonPbrLevels;
+    float4   gToonPbrAlphas;
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -108,6 +109,7 @@ cbuffer CBPerObject : register(b0)
 
     float4   gToonPbrCuts;
     float4   gToonPbrLevels;
+    float4   gToonPbrAlphas;
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -192,6 +194,7 @@ cbuffer CBPerObject : register(b0)
 
     float4   gToonPbrCuts;
     float4   gToonPbrLevels;
+    float4   gToonPbrAlphas;
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -293,6 +296,7 @@ cbuffer CBPerObject : register(b0)
 
     float4   gToonPbrCuts;
     float4   gToonPbrLevels;
+    float4   gToonPbrAlphas;
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -389,6 +393,7 @@ cbuffer CBPerObject : register(b0)
 
     float4   gToonPbrCuts;
     float4   gToonPbrLevels;
+    float4   gToonPbrAlphas;
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -411,6 +416,7 @@ struct GBufferOut
     float4 Metalness       : SV_Target1;
     float4 BaseColor       : SV_Target2;
     float4 ToonParams      : SV_Target3;
+    float4 ToonAlphas      : SV_Target4;
 };
 
 Texture2D  g_DiffuseMap : register(t0);
@@ -447,6 +453,7 @@ GBufferOut main(VertexOut pIn)
         gOut.NormalRoughness = float4(0.5f, 0.5f, 1.0f, 1.0f);
         gOut.Metalness  = float4(0.0f, 0.0f, 0.0f, 1.0f);
         gOut.ToonParams = float4(0.0f, 0.0f, 0.0f, 0.0f);
+        gOut.ToonAlphas = float4(1.0f, 1.0f, 1.0f, 1.0f);
         
         // 3. BaseColor: 아웃라인 색상
         // 4. Alpha (ShadingMode + AO) 인코딩: mode 6(OnlyTexture) + AO
@@ -520,6 +527,7 @@ GBufferOut main(VertexOut pIn)
     {
         gOut.ToonParams = float4(saturate(gEnvDiffuseStrength), saturate(gEnvSpecularStrength), 0.0f, 0.0f);
     }
+    gOut.ToonAlphas = float4(saturate(gToonPbrAlphas.xyz), 1.0f);
     // shadingMode + AO를 [0,1] 범위로 인코딩하여 저장
     gOut.BaseColor  = float4(baseColor, saturate(shadingEncoded));
     
@@ -658,7 +666,7 @@ float ToonLevel(float n)
     return 0.1f;
 }
 
-float ToonStepEditable(float n, float3 cuts, float3 levels, float strength, float blur)
+float ToonStepEditable(float n, float3 cuts, float3 levels, float3 alphas, float strength, float blur)
 {
     float c1 = saturate(cuts.x);
     float c2 = saturate(cuts.y);
@@ -671,6 +679,11 @@ float ToonStepEditable(float n, float3 cuts, float3 levels, float strength, floa
     float l2 = saturate(levels.z);
     float l3 = 1.0f;
 
+    float a0 = saturate(alphas.x);
+    float a1 = saturate(alphas.y);
+    float a2 = saturate(alphas.z);
+    float a3 = 1.0f;
+
     float t = saturate(strength);
     if (blur > 0.5f)
     {
@@ -682,14 +695,21 @@ float ToonStepEditable(float n, float3 cuts, float3 levels, float strength, floa
         float level = lerp(l0, l1, s1);
         level = lerp(level, l2, s2);
         level = lerp(level, l3, s3);
-        return lerp(n, level, t);
+        float alpha = lerp(a0, a1, s1);
+        alpha = lerp(alpha, a2, s2);
+        alpha = lerp(alpha, a3, s3);
+        return lerp(n, level, t * alpha);
     }
 
     float level = (n > c3) ? l3 :
                   (n > c2) ? l2 :
                   (n > c1) ? l1 :
                              l0;
-    return lerp(n, level, t);
+    float alpha = (n > c3) ? a3 :
+                  (n > c2) ? a2 :
+                  (n > c1) ? a1 :
+                             a0;
+    return lerp(n, level, t * alpha);
 }
 
 float2 Unpack2x8(float v)
@@ -755,12 +775,13 @@ Texture2D g_NormalRoughness : register(t0);
 Texture2D g_Metalness : register(t1);
 Texture2D g_BaseColor : register(t2);
 Texture2D g_ToonParams : register(t3);
-Texture2D<float> g_SceneDepth : register(t4);
-TextureCube g_IBL_Diffuse : register(t5);
-TextureCube g_IBL_Specular : register(t6);
-Texture2D   g_IBL_BRDF_LUT : register(t7);
-Texture2D<float> g_ShadowMap : register(t8);
-Texture2D g_DecalAlbedo : register(t9);
+Texture2D g_ToonAlphas : register(t4);
+Texture2D<float> g_SceneDepth : register(t5);
+TextureCube g_IBL_Diffuse : register(t6);
+TextureCube g_IBL_Specular : register(t7);
+Texture2D   g_IBL_BRDF_LUT : register(t8);
+Texture2D<float> g_ShadowMap : register(t9);
+Texture2D g_DecalAlbedo : register(t10);
 
 SamplerState g_Sam : register(s0);
 SamplerComparisonState g_ShadowSampler : register(s1);
@@ -947,6 +968,7 @@ float4 main(PS_INPUT_QUAD pIn) : SV_Target
     float4 metalness_packed = g_Metalness.Sample(g_Sam, pIn.uv);
     float4 baseColor = g_BaseColor.Sample(g_Sam, pIn.uv);
     float4 toonParams = g_ToonParams.Sample(g_Sam, pIn.uv);
+    float3 toonAlphas = g_ToonAlphas.Sample(g_Sam, pIn.uv).rgb;
     float4 decalAlbedo = g_DecalAlbedo.Sample(g_Sam, pIn.uv);
     float depth = g_SceneDepth.Sample(g_Sam, pIn.uv);
     
@@ -1083,7 +1105,7 @@ float4 main(PS_INPUT_QUAD pIn) : SV_Target
         float ndotl = max(dot(N, L), 0.0f);
         if (toonPbr && ndotl > 0.0f)
         {
-            float toonNdotL = toonEditable ? ToonStepEditable(ndotl, toonCuts, toonLevels, toonStrength, toonBlur) : ToonLevel(ndotl);
+            float toonNdotL = toonEditable ? ToonStepEditable(ndotl, toonCuts, toonLevels, toonAlphas, toonStrength, toonBlur) : ToonLevel(ndotl);
             lit *= toonNdotL / max(ndotl, 1e-4f);
         }
         directLighting += lit * shadowVis * ao;
@@ -1103,7 +1125,7 @@ float4 main(PS_INPUT_QUAD pIn) : SV_Target
         float ndotl = max(dot(N, Lp), 0.0f);
         if (toonPbr && ndotl > 0.0f)
         {
-            float toonNdotL = toonEditable ? ToonStepEditable(ndotl, toonCuts, toonLevels, toonStrength, toonBlur) : ToonLevel(ndotl);
+            float toonNdotL = toonEditable ? ToonStepEditable(ndotl, toonCuts, toonLevels, toonAlphas, toonStrength, toonBlur) : ToonLevel(ndotl);
             lit *= toonNdotL / max(ndotl, 1e-4f);
         }
         extraLighting += lit * ao;
@@ -1122,7 +1144,7 @@ float4 main(PS_INPUT_QUAD pIn) : SV_Target
         float ndotl = max(dot(N, Ls), 0.0f);
         if (toonPbr && ndotl > 0.0f)
         {
-            float toonNdotL = toonEditable ? ToonStepEditable(ndotl, toonCuts, toonLevels, toonStrength, toonBlur) : ToonLevel(ndotl);
+            float toonNdotL = toonEditable ? ToonStepEditable(ndotl, toonCuts, toonLevels, toonAlphas, toonStrength, toonBlur) : ToonLevel(ndotl);
             lit *= toonNdotL / max(ndotl, 1e-4f);
         }
         extraLighting += lit * ao;
@@ -1142,7 +1164,7 @@ float4 main(PS_INPUT_QUAD pIn) : SV_Target
         float ndotl = max(dot(N, Lr), 0.0f);
         if (toonPbr && ndotl > 0.0f)
         {
-            float toonNdotL = toonEditable ? ToonStepEditable(ndotl, toonCuts, toonLevels, toonStrength, toonBlur) : ToonLevel(ndotl);
+            float toonNdotL = toonEditable ? ToonStepEditable(ndotl, toonCuts, toonLevels, toonAlphas, toonStrength, toonBlur) : ToonLevel(ndotl);
             lit *= toonNdotL / max(ndotl, 1e-4f);
         }
         extraLighting += lit * ao;
@@ -1195,6 +1217,7 @@ cbuffer CBPerObject : register(b0)
 
     float4   gToonPbrCuts;
     float4   gToonPbrLevels;
+    float4   gToonPbrAlphas;
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -1296,6 +1319,7 @@ cbuffer CBPerObject : register(b0)
 
     float4   gToonPbrCuts;
     float4   gToonPbrLevels;
+    float4   gToonPbrAlphas;
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -1415,7 +1439,7 @@ float ToonLevel(float n)
     return 0.1f;
 }
 
-float ToonStepEditable(float n, float3 cuts, float3 levels, float strength, float blur)
+float ToonStepEditable(float n, float3 cuts, float3 levels, float3 alphas, float strength, float blur)
 {
     float c1 = saturate(cuts.x);
     float c2 = saturate(cuts.y);
@@ -1428,6 +1452,11 @@ float ToonStepEditable(float n, float3 cuts, float3 levels, float strength, floa
     float l2 = saturate(levels.z);
     float l3 = 1.0f;
 
+    float a0 = saturate(alphas.x);
+    float a1 = saturate(alphas.y);
+    float a2 = saturate(alphas.z);
+    float a3 = 1.0f;
+
     float t = saturate(strength);
     if (blur > 0.5f)
     {
@@ -1439,14 +1468,21 @@ float ToonStepEditable(float n, float3 cuts, float3 levels, float strength, floa
         float level = lerp(l0, l1, s1);
         level = lerp(level, l2, s2);
         level = lerp(level, l3, s3);
-        return lerp(n, level, t);
+        float alpha = lerp(a0, a1, s1);
+        alpha = lerp(alpha, a2, s2);
+        alpha = lerp(alpha, a3, s3);
+        return lerp(n, level, t * alpha);
     }
 
     float level = (n > c3) ? l3 :
                   (n > c2) ? l2 :
                   (n > c1) ? l1 :
                              l0;
-    return lerp(n, level, t);
+    float alpha = (n > c3) ? a3 :
+                  (n > c2) ? a2 :
+                  (n > c1) ? a1 :
+                             a0;
+    return lerp(n, level, t * alpha);
 }
 
 // 텍스처
@@ -1484,6 +1520,7 @@ cbuffer CBPerObject : register(b0)
 
     float4   gToonPbrCuts;
     float4   gToonPbrLevels;
+    float4   gToonPbrAlphas;
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -1608,7 +1645,7 @@ float4 main(PSIn pIn) : SV_Target
     if (toonPbr && NdotL > 0.0f)
     {
         float toonNdotL = toonEditable
-            ? ToonStepEditable(NdotL, gToonPbrCuts.xyz, gToonPbrLevels.xyz, gToonPbrCuts.w, gToonPbrLevels.w)
+            ? ToonStepEditable(NdotL, gToonPbrCuts.xyz, gToonPbrLevels.xyz, gToonPbrAlphas.xyz, gToonPbrCuts.w, gToonPbrLevels.w)
             : ToonLevel(NdotL);
         direct *= toonNdotL / max(NdotL, 1e-4f);
     }
@@ -1656,6 +1693,7 @@ cbuffer CBPerObject : register(b0)
 
     float4   gToonPbrCuts;
     float4   gToonPbrLevels;
+    float4   gToonPbrAlphas;
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -1707,6 +1745,7 @@ cbuffer CBPerObject : register(b0)
 
     float4   gToonPbrCuts;
     float4   gToonPbrLevels;
+    float4   gToonPbrAlphas;
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -1768,6 +1807,7 @@ cbuffer CBPerObject : register(b0)
 
     float4   gToonPbrCuts;
     float4   gToonPbrLevels;
+    float4   gToonPbrAlphas;
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -1849,6 +1889,7 @@ cbuffer CBPerObject : register(b0)
 
     float4   gToonPbrCuts;
     float4   gToonPbrLevels;
+    float4   gToonPbrAlphas;
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -1966,3 +2007,4 @@ PS_INPUT main(uint vid : SV_VertexID)
 )";
     };
 }
+

--- a/Engine/src/Runtime/Rendering/ShaderCode/DeferredShader.h
+++ b/Engine/src/Runtime/Rendering/ShaderCode/DeferredShader.h
@@ -34,7 +34,7 @@ cbuffer CBPerObject : register(b0)
     float4   gToonPbrLevels;
     float4   gToonPbrAlphas;
     float    gToonPbrRampIntensity;
-
+    float    gToonSelfShadowStrength;
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -113,7 +113,7 @@ cbuffer CBPerObject : register(b0)
     float4   gToonPbrLevels;
     float4   gToonPbrAlphas;
     float    gToonPbrRampIntensity;
-
+    float    gToonSelfShadowStrength;
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -200,7 +200,7 @@ cbuffer CBPerObject : register(b0)
     float4   gToonPbrLevels;
     float4   gToonPbrAlphas;
     float    gToonPbrRampIntensity;
-
+    float    gToonSelfShadowStrength;
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -304,7 +304,7 @@ cbuffer CBPerObject : register(b0)
     float4   gToonPbrLevels;
     float4   gToonPbrAlphas;
     float    gToonPbrRampIntensity;
-
+    float    gToonSelfShadowStrength;
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -403,7 +403,7 @@ cbuffer CBPerObject : register(b0)
     float4   gToonPbrLevels;
     float4   gToonPbrAlphas;
     float    gToonPbrRampIntensity;
-
+    float    gToonSelfShadowStrength;
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -538,7 +538,8 @@ GBufferOut main(VertexOut pIn)
     {
         gOut.ToonParams = float4(saturate(gEnvDiffuseStrength), saturate(gEnvSpecularStrength), 0.0f, 0.0f);
     }
-    gOut.ToonAlphas = float4(saturate(gToonPbrAlphas.xyz), saturate(gToonPbrAlphas.w));
+    float packedShadowSelf = Pack2x8(gToonPbrAlphas.w, gToonSelfShadowStrength);
+    gOut.ToonAlphas = float4(saturate(gToonPbrAlphas.xyz), packedShadowSelf);
     // shadingMode + AO를 [0,1] 범위로 인코딩하여 저장
     gOut.BaseColor  = float4(baseColor, saturate(shadingEncoded));
     
@@ -988,7 +989,9 @@ float4 main(PS_INPUT_QUAD pIn) : SV_Target
     float4 toonParams = g_ToonParams.Sample(g_Sam, pIn.uv);
     float4 toonAlphasSample = g_ToonAlphas.Sample(g_Sam, pIn.uv);
     float3 toonAlphas = toonAlphasSample.rgb;
-    float  materialShadowStrength = toonAlphasSample.a;
+    float2 shadowSelfPacked = Unpack2x8(toonAlphasSample.a);
+    float  materialShadowStrength = shadowSelfPacked.x;
+    float  toonSelfShadowStrength = shadowSelfPacked.y;
     float4 decalAlbedo = g_DecalAlbedo.Sample(g_Sam, pIn.uv);
     float depth = g_SceneDepth.Sample(g_Sam, pIn.uv);
     
@@ -1066,6 +1069,8 @@ float4 main(PS_INPUT_QUAD pIn) : SV_Target
     if (toonEditable)
     {
         shadowStrength *= saturate(g_ToonShadowStrength2);
+        const float kToonPbrShadowAtten = 0.35f;
+        shadowStrength *= kToonPbrShadowAtten;
     }
     shadowVis = saturate(lerp(1.0f, shadowVis, shadowStrength));
 
@@ -1138,6 +1143,7 @@ float4 main(PS_INPUT_QUAD pIn) : SV_Target
         if (toonPbr && ndotl > 0.0f)
         {
             float toonNdotL = toonEditable ? ToonStepEditable(ndotl, toonCuts, toonLevels, toonAlphas, toonStrength, toonBlur, toonRampIntensity) : ToonLevel(ndotl);
+            if (toonEditable) toonNdotL = lerp(ndotl, toonNdotL, saturate(toonSelfShadowStrength));
             lit *= toonNdotL / max(ndotl, 1e-4f);
         }
         directLighting += lit * shadowVis * ao;
@@ -1158,6 +1164,7 @@ float4 main(PS_INPUT_QUAD pIn) : SV_Target
         if (toonPbr && ndotl > 0.0f)
         {
             float toonNdotL = toonEditable ? ToonStepEditable(ndotl, toonCuts, toonLevels, toonAlphas, toonStrength, toonBlur, toonRampIntensity) : ToonLevel(ndotl);
+            if (toonEditable) toonNdotL = lerp(ndotl, toonNdotL, saturate(toonSelfShadowStrength));
             lit *= toonNdotL / max(ndotl, 1e-4f);
         }
         extraLighting += lit * ao;
@@ -1177,6 +1184,7 @@ float4 main(PS_INPUT_QUAD pIn) : SV_Target
         if (toonPbr && ndotl > 0.0f)
         {
             float toonNdotL = toonEditable ? ToonStepEditable(ndotl, toonCuts, toonLevels, toonAlphas, toonStrength, toonBlur, toonRampIntensity) : ToonLevel(ndotl);
+            if (toonEditable) toonNdotL = lerp(ndotl, toonNdotL, saturate(toonSelfShadowStrength));
             lit *= toonNdotL / max(ndotl, 1e-4f);
         }
         extraLighting += lit * ao;
@@ -1197,6 +1205,7 @@ float4 main(PS_INPUT_QUAD pIn) : SV_Target
         if (toonPbr && ndotl > 0.0f)
         {
             float toonNdotL = toonEditable ? ToonStepEditable(ndotl, toonCuts, toonLevels, toonAlphas, toonStrength, toonBlur, toonRampIntensity) : ToonLevel(ndotl);
+            if (toonEditable) toonNdotL = lerp(ndotl, toonNdotL, saturate(toonSelfShadowStrength));
             lit *= toonNdotL / max(ndotl, 1e-4f);
         }
         extraLighting += lit * ao;
@@ -1251,7 +1260,7 @@ cbuffer CBPerObject : register(b0)
     float4   gToonPbrLevels;
     float4   gToonPbrAlphas;
     float    gToonPbrRampIntensity;
-
+    float    gToonSelfShadowStrength;
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -1355,7 +1364,7 @@ cbuffer CBPerObject : register(b0)
     float4   gToonPbrLevels;
     float4   gToonPbrAlphas;
     float    gToonPbrRampIntensity;
-
+    float    gToonSelfShadowStrength;
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -1563,7 +1572,7 @@ cbuffer CBPerObject : register(b0)
     float4   gToonPbrLevels;
     float4   gToonPbrAlphas;
     float    gToonPbrRampIntensity;
-
+    float    gToonSelfShadowStrength;
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -1690,6 +1699,7 @@ float4 main(PSIn pIn) : SV_Target
         float toonNdotL = toonEditable
             ? ToonStepEditable(NdotL, gToonPbrCuts.xyz, gToonPbrLevels.xyz, gToonPbrAlphas.xyz, gToonPbrCuts.w, gToonPbrLevels.w, gToonPbrRampIntensity)
             : ToonLevel(NdotL);
+        if (toonEditable) toonNdotL = lerp(NdotL, toonNdotL, saturate(gToonSelfShadowStrength));
         direct *= toonNdotL / max(NdotL, 1e-4f);
     }
 
@@ -1738,7 +1748,7 @@ cbuffer CBPerObject : register(b0)
     float4   gToonPbrLevels;
     float4   gToonPbrAlphas;
     float    gToonPbrRampIntensity;
-
+    float    gToonSelfShadowStrength;
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -1792,7 +1802,7 @@ cbuffer CBPerObject : register(b0)
     float4   gToonPbrLevels;
     float4   gToonPbrAlphas;
     float    gToonPbrRampIntensity;
-
+    float    gToonSelfShadowStrength;
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -1856,7 +1866,7 @@ cbuffer CBPerObject : register(b0)
     float4   gToonPbrLevels;
     float4   gToonPbrAlphas;
     float    gToonPbrRampIntensity;
-
+    float    gToonSelfShadowStrength;
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -1940,7 +1950,7 @@ cbuffer CBPerObject : register(b0)
     float4   gToonPbrLevels;
     float4   gToonPbrAlphas;
     float    gToonPbrRampIntensity;
-
+    float    gToonSelfShadowStrength;
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;

--- a/Engine/src/Runtime/Rendering/ShaderCode/DeferredShader.h
+++ b/Engine/src/Runtime/Rendering/ShaderCode/DeferredShader.h
@@ -33,6 +33,8 @@ cbuffer CBPerObject : register(b0)
     float4   gToonPbrCuts;
     float4   gToonPbrLevels;
     float4   gToonPbrAlphas;
+    float    gToonPbrRampIntensity;
+
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -110,6 +112,8 @@ cbuffer CBPerObject : register(b0)
     float4   gToonPbrCuts;
     float4   gToonPbrLevels;
     float4   gToonPbrAlphas;
+    float    gToonPbrRampIntensity;
+
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -195,6 +199,8 @@ cbuffer CBPerObject : register(b0)
     float4   gToonPbrCuts;
     float4   gToonPbrLevels;
     float4   gToonPbrAlphas;
+    float    gToonPbrRampIntensity;
+
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -297,6 +303,8 @@ cbuffer CBPerObject : register(b0)
     float4   gToonPbrCuts;
     float4   gToonPbrLevels;
     float4   gToonPbrAlphas;
+    float    gToonPbrRampIntensity;
+
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -394,6 +402,8 @@ cbuffer CBPerObject : register(b0)
     float4   gToonPbrCuts;
     float4   gToonPbrLevels;
     float4   gToonPbrAlphas;
+    float    gToonPbrRampIntensity;
+
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -520,8 +530,9 @@ GBufferOut main(VertexOut pIn)
     if (isToonPbr)
     {
         float packedLevels12 = Pack2x8(gToonPbrLevels.x, gToonPbrLevels.y);
+        float packedLevel3Ramp = Pack2x8(saturate(gToonPbrLevels.z), saturate(gToonPbrRampIntensity));
         float packedEnv = Pack2x8(gEnvDiffuseStrength, gEnvSpecularStrength);
-        gOut.ToonParams = float4(toonStrengthPacked, packedLevels12, saturate(gToonPbrLevels.z), packedEnv);
+        gOut.ToonParams = float4(toonStrengthPacked, packedLevels12, packedLevel3Ramp, packedEnv);
     }
     else
     {
@@ -666,7 +677,7 @@ float ToonLevel(float n)
     return 0.1f;
 }
 
-float ToonStepEditable(float n, float3 cuts, float3 levels, float3 alphas, float strength, float blur)
+float ToonStepEditable(float n, float3 cuts, float3 levels, float3 alphas, float strength, float blur, float rampIntensity)
 {
     float c1 = saturate(cuts.x);
     float c2 = saturate(cuts.y);
@@ -685,6 +696,7 @@ float ToonStepEditable(float n, float3 cuts, float3 levels, float3 alphas, float
     float a3 = 1.0f;
 
     float t = saturate(strength);
+    float ramp = saturate(rampIntensity);
     if (blur > 0.5f)
     {
         float w = max(fwidth(n) * 2.0f, 0.02f);
@@ -698,6 +710,8 @@ float ToonStepEditable(float n, float3 cuts, float3 levels, float3 alphas, float
         float alpha = lerp(a0, a1, s1);
         alpha = lerp(alpha, a2, s2);
         alpha = lerp(alpha, a3, s3);
+        float darkMask = 1.0f - s1;
+        alpha *= (1.0f - ramp * darkMask);
         return lerp(n, level, t * alpha);
     }
 
@@ -709,6 +723,8 @@ float ToonStepEditable(float n, float3 cuts, float3 levels, float3 alphas, float
                   (n > c2) ? a2 :
                   (n > c1) ? a1 :
                              a0;
+    float darkMask = (n > c1) ? 0.0f : 1.0f;
+    alpha *= (1.0f - ramp * darkMask);
     return lerp(n, level, t * alpha);
 }
 
@@ -1025,10 +1041,13 @@ float4 main(PS_INPUT_QUAD pIn) : SV_Target
     const bool toonEditable = (shadingMode == 7);
     float envDiffuseStrength = 1.0f;
     float envSpecularStrength = 1.0f;
+    float toonRampIntensity = 0.0f;
     if (toonPbr)
     {
         float2 levels12 = Unpack2x8(toonParams.g);
-        toonLevels = float3(levels12.x, levels12.y, toonParams.b);
+        float2 level3Ramp = Unpack2x8(toonParams.b);
+        toonLevels = float3(levels12.x, levels12.y, level3Ramp.x);
+        toonRampIntensity = level3Ramp.y;
         float2 env = Unpack2x8(toonParams.a);
         envDiffuseStrength = env.x;
         envSpecularStrength = env.y;
@@ -1037,15 +1056,18 @@ float4 main(PS_INPUT_QUAD pIn) : SV_Target
     {
         envDiffuseStrength = toonParams.r;
         envSpecularStrength = toonParams.g;
+        toonRampIntensity = 0.0f;
     }
 
     float shadowVis = CalcShadowFactorDeferred(posW, g_ShadowMap, g_ShadowSampler);
-    float shadowStrength = saturate(g_ShadowStrength2) * saturate(materialShadowStrength);
+    const float kShadowStrengthMax = 12.0f;
+    float shadowStrength = saturate(g_ShadowStrength2) * kShadowStrengthMax;
+    shadowStrength *= saturate(materialShadowStrength);
     if (toonEditable)
     {
         shadowStrength *= saturate(g_ToonShadowStrength2);
     }
-    shadowVis = lerp(1.0f, shadowVis, shadowStrength);
+    shadowVis = saturate(lerp(1.0f, shadowVis, shadowStrength));
 
     if (!usePbr)
     {
@@ -1115,7 +1137,7 @@ float4 main(PS_INPUT_QUAD pIn) : SV_Target
         float ndotl = max(dot(N, L), 0.0f);
         if (toonPbr && ndotl > 0.0f)
         {
-            float toonNdotL = toonEditable ? ToonStepEditable(ndotl, toonCuts, toonLevels, toonAlphas, toonStrength, toonBlur) : ToonLevel(ndotl);
+            float toonNdotL = toonEditable ? ToonStepEditable(ndotl, toonCuts, toonLevels, toonAlphas, toonStrength, toonBlur, toonRampIntensity) : ToonLevel(ndotl);
             lit *= toonNdotL / max(ndotl, 1e-4f);
         }
         directLighting += lit * shadowVis * ao;
@@ -1135,7 +1157,7 @@ float4 main(PS_INPUT_QUAD pIn) : SV_Target
         float ndotl = max(dot(N, Lp), 0.0f);
         if (toonPbr && ndotl > 0.0f)
         {
-            float toonNdotL = toonEditable ? ToonStepEditable(ndotl, toonCuts, toonLevels, toonAlphas, toonStrength, toonBlur) : ToonLevel(ndotl);
+            float toonNdotL = toonEditable ? ToonStepEditable(ndotl, toonCuts, toonLevels, toonAlphas, toonStrength, toonBlur, toonRampIntensity) : ToonLevel(ndotl);
             lit *= toonNdotL / max(ndotl, 1e-4f);
         }
         extraLighting += lit * ao;
@@ -1154,7 +1176,7 @@ float4 main(PS_INPUT_QUAD pIn) : SV_Target
         float ndotl = max(dot(N, Ls), 0.0f);
         if (toonPbr && ndotl > 0.0f)
         {
-            float toonNdotL = toonEditable ? ToonStepEditable(ndotl, toonCuts, toonLevels, toonAlphas, toonStrength, toonBlur) : ToonLevel(ndotl);
+            float toonNdotL = toonEditable ? ToonStepEditable(ndotl, toonCuts, toonLevels, toonAlphas, toonStrength, toonBlur, toonRampIntensity) : ToonLevel(ndotl);
             lit *= toonNdotL / max(ndotl, 1e-4f);
         }
         extraLighting += lit * ao;
@@ -1174,7 +1196,7 @@ float4 main(PS_INPUT_QUAD pIn) : SV_Target
         float ndotl = max(dot(N, Lr), 0.0f);
         if (toonPbr && ndotl > 0.0f)
         {
-            float toonNdotL = toonEditable ? ToonStepEditable(ndotl, toonCuts, toonLevels, toonAlphas, toonStrength, toonBlur) : ToonLevel(ndotl);
+            float toonNdotL = toonEditable ? ToonStepEditable(ndotl, toonCuts, toonLevels, toonAlphas, toonStrength, toonBlur, toonRampIntensity) : ToonLevel(ndotl);
             lit *= toonNdotL / max(ndotl, 1e-4f);
         }
         extraLighting += lit * ao;
@@ -1228,6 +1250,8 @@ cbuffer CBPerObject : register(b0)
     float4   gToonPbrCuts;
     float4   gToonPbrLevels;
     float4   gToonPbrAlphas;
+    float    gToonPbrRampIntensity;
+
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -1330,6 +1354,8 @@ cbuffer CBPerObject : register(b0)
     float4   gToonPbrCuts;
     float4   gToonPbrLevels;
     float4   gToonPbrAlphas;
+    float    gToonPbrRampIntensity;
+
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -1449,7 +1475,7 @@ float ToonLevel(float n)
     return 0.1f;
 }
 
-float ToonStepEditable(float n, float3 cuts, float3 levels, float3 alphas, float strength, float blur)
+float ToonStepEditable(float n, float3 cuts, float3 levels, float3 alphas, float strength, float blur, float rampIntensity)
 {
     float c1 = saturate(cuts.x);
     float c2 = saturate(cuts.y);
@@ -1468,6 +1494,7 @@ float ToonStepEditable(float n, float3 cuts, float3 levels, float3 alphas, float
     float a3 = 1.0f;
 
     float t = saturate(strength);
+    float ramp = saturate(rampIntensity);
     if (blur > 0.5f)
     {
         float w = max(fwidth(n) * 2.0f, 0.02f);
@@ -1481,6 +1508,8 @@ float ToonStepEditable(float n, float3 cuts, float3 levels, float3 alphas, float
         float alpha = lerp(a0, a1, s1);
         alpha = lerp(alpha, a2, s2);
         alpha = lerp(alpha, a3, s3);
+        float darkMask = 1.0f - s1;
+        alpha *= (1.0f - ramp * darkMask);
         return lerp(n, level, t * alpha);
     }
 
@@ -1492,6 +1521,8 @@ float ToonStepEditable(float n, float3 cuts, float3 levels, float3 alphas, float
                   (n > c2) ? a2 :
                   (n > c1) ? a1 :
                              a0;
+    float darkMask = (n > c1) ? 0.0f : 1.0f;
+    alpha *= (1.0f - ramp * darkMask);
     return lerp(n, level, t * alpha);
 }
 
@@ -1531,6 +1562,8 @@ cbuffer CBPerObject : register(b0)
     float4   gToonPbrCuts;
     float4   gToonPbrLevels;
     float4   gToonPbrAlphas;
+    float    gToonPbrRampIntensity;
+
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -1655,7 +1688,7 @@ float4 main(PSIn pIn) : SV_Target
     if (toonPbr && NdotL > 0.0f)
     {
         float toonNdotL = toonEditable
-            ? ToonStepEditable(NdotL, gToonPbrCuts.xyz, gToonPbrLevels.xyz, gToonPbrAlphas.xyz, gToonPbrCuts.w, gToonPbrLevels.w)
+            ? ToonStepEditable(NdotL, gToonPbrCuts.xyz, gToonPbrLevels.xyz, gToonPbrAlphas.xyz, gToonPbrCuts.w, gToonPbrLevels.w, gToonPbrRampIntensity)
             : ToonLevel(NdotL);
         direct *= toonNdotL / max(NdotL, 1e-4f);
     }
@@ -1704,6 +1737,8 @@ cbuffer CBPerObject : register(b0)
     float4   gToonPbrCuts;
     float4   gToonPbrLevels;
     float4   gToonPbrAlphas;
+    float    gToonPbrRampIntensity;
+
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -1756,6 +1791,8 @@ cbuffer CBPerObject : register(b0)
     float4   gToonPbrCuts;
     float4   gToonPbrLevels;
     float4   gToonPbrAlphas;
+    float    gToonPbrRampIntensity;
+
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -1818,6 +1855,8 @@ cbuffer CBPerObject : register(b0)
     float4   gToonPbrCuts;
     float4   gToonPbrLevels;
     float4   gToonPbrAlphas;
+    float    gToonPbrRampIntensity;
+
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -1900,6 +1939,8 @@ cbuffer CBPerObject : register(b0)
     float4   gToonPbrCuts;
     float4   gToonPbrLevels;
     float4   gToonPbrAlphas;
+    float    gToonPbrRampIntensity;
+
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;

--- a/Engine/src/Runtime/Rendering/ShaderCode/DeferredShader.h
+++ b/Engine/src/Runtime/Rendering/ShaderCode/DeferredShader.h
@@ -1019,7 +1019,9 @@ float4 main(PS_INPUT_QUAD pIn) : SV_Target
     // Decal (premultiplied)
     baseColor.rgb = baseColor.rgb * (1.0f - decalAlbedo.a) + decalAlbedo.rgb;
     float3 albedo = baseColor.rgb;
-    float3 albedoLinear = pow(max(albedo, 0.0f), 2.2f);
+    // g_BaseColor는 SRGB RT에 기록되어 샘플 시 이미 linear로 복원됩니다.
+    // 여기서 추가 gamma 변환을 하면 백화(과노출)처럼 보이는 이중 변환이 발생합니다.
+    float3 albedoLinear = max(albedo, 0.0f);
     
     // shadingMode + AO 디코딩
     float modeAo = saturate(baseColor.a) * 8.0f;
@@ -1660,7 +1662,8 @@ float4 main(PSIn pIn) : SV_Target
         return float4(baseColor, alphaOut);
     }
 
-    float3 albedoLinear = pow(max(baseColor, 0.0f), 2.2f);
+    // 컬러 텍스처 샘플은 이미 linear 공간입니다.
+    float3 albedoLinear = max(baseColor, 0.0f);
 
     float3 N = normalize(pIn.Normal);
     if (gEnableNormalMap != 0)

--- a/Engine/src/Runtime/Rendering/ShaderCode/ForwardShader.h
+++ b/Engine/src/Runtime/Rendering/ShaderCode/ForwardShader.h
@@ -34,7 +34,7 @@ cbuffer CBPerObject : register(b0)
     // ToonPBREditable 파라미터
     float4   gToonPbrCuts;   // (cut1, cut2, cut3, strength)
     float4   gToonPbrLevels;
-    float4   gToonPbrAlphas; // (level1, level2, level3, unused)
+    float4   gToonPbrAlphas; // (level1, level2, level3, shadowStrength)
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -114,7 +114,7 @@ cbuffer CBPerObject : register(b0)
     // ToonPBREditable 파라미터
     float4   gToonPbrCuts;   // (cut1, cut2, cut3, strength)
     float4   gToonPbrLevels;
-    float4   gToonPbrAlphas; // (level1, level2, level3, unused)
+    float4   gToonPbrAlphas; // (level1, level2, level3, shadowStrength)
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -226,7 +226,7 @@ cbuffer CBPerObject : register(b0)
     // ToonPBREditable 파라미터
     float4   gToonPbrCuts;   // (cut1, cut2, cut3, strength)
     float4   gToonPbrLevels;
-    float4   gToonPbrAlphas; // (level1, level2, level3, unused)
+    float4   gToonPbrAlphas; // (level1, level2, level3, shadowStrength)
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -333,7 +333,7 @@ cbuffer CBPerObject : register(b0)
     // ToonPBREditable 파라미터
     float4   gToonPbrCuts;   // (cut1, cut2, cut3, strength)
     float4   gToonPbrLevels;
-    float4   gToonPbrAlphas; // (level1, level2, level3, unused)
+    float4   gToonPbrAlphas; // (level1, level2, level3, shadowStrength)
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -372,6 +372,9 @@ cbuffer CBLighting : register(b1)
     float  gShadowMapSize;
     float  gShadowPCFRadius;
     int    gShadowEnabled;
+    float  gShadowStrength;
+    float  gToonShadowStrength;
+    float2 gShadowPad;
 };
 
 #define MAX_POINT_LIGHTS 16
@@ -775,6 +778,14 @@ float4 main(PSInput input) : SV_TARGET
         }
         }
     }
+
+    // 전역 + 머티리얼 + ToonPBREditable 보정 강도 적용
+    float shadowStrength = saturate(gShadowStrength) * saturate(gToonPbrAlphas.w);
+    if (gShadingMode == 7)
+    {
+        shadowStrength *= saturate(gToonShadowStrength);
+    }
+    shadow = lerp(1.0f, shadow, shadowStrength);
 
     totalDiffuse  *= shadow;
     totalSpecular *= shadow;

--- a/Engine/src/Runtime/Rendering/ShaderCode/ForwardShader.h
+++ b/Engine/src/Runtime/Rendering/ShaderCode/ForwardShader.h
@@ -938,8 +938,16 @@ float4 main(PSInput input) : SV_TARGET
         specularIBL *= gEnvSpecularStrength;
 
         // 최종 색상 = 직접광 + 간접광(IBL)
-        float shadowIBL = lerp(0.35f, 1.0f, shadow);
-        float3 colorPbr = Lo + (diffuseIBL * shadowIBL + specularIBL) * ao;
+        // ToonPBREditable은 외부 오브젝트 그림자를 명확히 받도록 IBL도 shadow에 연동합니다.
+        float shadowIBLDiffuse = lerp(0.35f, 1.0f, shadow);
+        float shadowIBLSpecular = 1.0f;
+        if (gShadingMode == 7)
+        {
+            shadowIBLDiffuse = shadow;
+            shadowIBLSpecular = lerp(0.25f, 1.0f, shadow);
+        }
+
+        float3 colorPbr = Lo + (diffuseIBL * shadowIBLDiffuse + specularIBL * shadowIBLSpecular) * ao;
 
         return float4(colorPbr, alphaOut);
     }

--- a/Engine/src/Runtime/Rendering/ShaderCode/ForwardShader.h
+++ b/Engine/src/Runtime/Rendering/ShaderCode/ForwardShader.h
@@ -36,6 +36,7 @@ cbuffer CBPerObject : register(b0)
     float4   gToonPbrLevels;
     float4   gToonPbrAlphas; // (level1, level2, level3, shadowStrength)
     float    gToonPbrRampIntensity;
+    float    gToonSelfShadowStrength;
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -117,6 +118,7 @@ cbuffer CBPerObject : register(b0)
     float4   gToonPbrLevels;
     float4   gToonPbrAlphas; // (level1, level2, level3, shadowStrength)
     float    gToonPbrRampIntensity;
+    float    gToonSelfShadowStrength;
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -230,6 +232,7 @@ cbuffer CBPerObject : register(b0)
     float4   gToonPbrLevels;
     float4   gToonPbrAlphas; // (level1, level2, level3, shadowStrength)
     float    gToonPbrRampIntensity;
+    float    gToonSelfShadowStrength;
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -338,6 +341,7 @@ cbuffer CBPerObject : register(b0)
     float4   gToonPbrLevels;
     float4   gToonPbrAlphas; // (level1, level2, level3, shadowStrength)
     float    gToonPbrRampIntensity;
+    float    gToonSelfShadowStrength;
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -581,7 +585,8 @@ float ToonPbrNdotL(float n)
 {
     if (gShadingMode == 7)
     {
-         return ToonStepEditable(n, gToonPbrCuts.xyz, gToonPbrLevels.xyz, gToonPbrAlphas.xyz, gToonPbrCuts.w, gToonPbrLevels.w, gToonPbrRampIntensity);
+         float toon = ToonStepEditable(n, gToonPbrCuts.xyz, gToonPbrLevels.xyz, gToonPbrAlphas.xyz, gToonPbrCuts.w, gToonPbrLevels.w, gToonPbrRampIntensity);
+         return lerp(n, toon, saturate(gToonSelfShadowStrength));
     }
     return ToonLevel(n);
 }
@@ -795,6 +800,8 @@ float4 main(PSInput input) : SV_TARGET
     if (gShadingMode == 7)
     {
         shadowStrength *= saturate(gToonShadowStrength);
+        const float kToonPbrShadowAtten = 0.35f;
+        shadowStrength *= kToonPbrShadowAtten;
     }
     shadow = saturate(lerp(1.0f, shadow, shadowStrength));
 

--- a/Engine/src/Runtime/Rendering/ShaderCode/ForwardShader.h
+++ b/Engine/src/Runtime/Rendering/ShaderCode/ForwardShader.h
@@ -33,7 +33,8 @@ cbuffer CBPerObject : register(b0)
 
     // ToonPBREditable 파라미터
     float4   gToonPbrCuts;   // (cut1, cut2, cut3, strength)
-    float4   gToonPbrLevels; // (level1, level2, level3, unused)
+    float4   gToonPbrLevels;
+    float4   gToonPbrAlphas; // (level1, level2, level3, unused)
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -112,7 +113,8 @@ cbuffer CBPerObject : register(b0)
 
     // ToonPBREditable 파라미터
     float4   gToonPbrCuts;   // (cut1, cut2, cut3, strength)
-    float4   gToonPbrLevels; // (level1, level2, level3, unused)
+    float4   gToonPbrLevels;
+    float4   gToonPbrAlphas; // (level1, level2, level3, unused)
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -223,7 +225,8 @@ cbuffer CBPerObject : register(b0)
 
     // ToonPBREditable 파라미터
     float4   gToonPbrCuts;   // (cut1, cut2, cut3, strength)
-    float4   gToonPbrLevels; // (level1, level2, level3, unused)
+    float4   gToonPbrLevels;
+    float4   gToonPbrAlphas; // (level1, level2, level3, unused)
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -329,7 +332,8 @@ cbuffer CBPerObject : register(b0)
 
     // ToonPBREditable 파라미터
     float4   gToonPbrCuts;   // (cut1, cut2, cut3, strength)
-    float4   gToonPbrLevels; // (level1, level2, level3, unused)
+    float4   gToonPbrLevels;
+    float4   gToonPbrAlphas; // (level1, level2, level3, unused)
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -515,7 +519,7 @@ float ToonLevel(float n)
     return 0.1f;
 }
 
-float ToonStepEditable(float n, float3 cuts, float3 levels, float strength, float blur)
+float ToonStepEditable(float n, float3 cuts, float3 levels, float3 alphas, float strength, float blur)
 {
     float c1 = saturate(cuts.x);
     float c2 = saturate(cuts.y);
@@ -528,6 +532,11 @@ float ToonStepEditable(float n, float3 cuts, float3 levels, float strength, floa
     float l2 = saturate(levels.z);
     float l3 = 1.0f;
 
+    float a0 = saturate(alphas.x);
+    float a1 = saturate(alphas.y);
+    float a2 = saturate(alphas.z);
+    float a3 = 1.0f;
+
     float t = saturate(strength);
     if (blur > 0.5f)
     {
@@ -539,21 +548,28 @@ float ToonStepEditable(float n, float3 cuts, float3 levels, float strength, floa
         float level = lerp(l0, l1, s1);
         level = lerp(level, l2, s2);
         level = lerp(level, l3, s3);
-        return lerp(n, level, t);
+        float alpha = lerp(a0, a1, s1);
+        alpha = lerp(alpha, a2, s2);
+        alpha = lerp(alpha, a3, s3);
+        return lerp(n, level, t * alpha);
     }
 
     float level = (n > c3) ? l3 :
                   (n > c2) ? l2 :
                   (n > c1) ? l1 :
                              l0;
-    return lerp(n, level, t);
+    float alpha = (n > c3) ? a3 :
+                  (n > c2) ? a2 :
+                  (n > c1) ? a1 :
+                             a0;
+    return lerp(n, level, t * alpha);
 }
 
 float ToonPbrNdotL(float n)
 {
     if (gShadingMode == 7)
     {
-         return ToonStepEditable(n, gToonPbrCuts.xyz, gToonPbrLevels.xyz, gToonPbrCuts.w, gToonPbrLevels.w);
+         return ToonStepEditable(n, gToonPbrCuts.xyz, gToonPbrLevels.xyz, gToonPbrAlphas.xyz, gToonPbrCuts.w, gToonPbrLevels.w);
     }
     return ToonLevel(n);
 }
@@ -1049,3 +1065,4 @@ float4 main(PSInput input) : SV_Target
 )";
     };
 }
+

--- a/Engine/src/Runtime/Rendering/ShaderCode/ForwardShader.h
+++ b/Engine/src/Runtime/Rendering/ShaderCode/ForwardShader.h
@@ -35,6 +35,7 @@ cbuffer CBPerObject : register(b0)
     float4   gToonPbrCuts;   // (cut1, cut2, cut3, strength)
     float4   gToonPbrLevels;
     float4   gToonPbrAlphas; // (level1, level2, level3, shadowStrength)
+    float    gToonPbrRampIntensity;
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -115,6 +116,7 @@ cbuffer CBPerObject : register(b0)
     float4   gToonPbrCuts;   // (cut1, cut2, cut3, strength)
     float4   gToonPbrLevels;
     float4   gToonPbrAlphas; // (level1, level2, level3, shadowStrength)
+    float    gToonPbrRampIntensity;
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -227,6 +229,7 @@ cbuffer CBPerObject : register(b0)
     float4   gToonPbrCuts;   // (cut1, cut2, cut3, strength)
     float4   gToonPbrLevels;
     float4   gToonPbrAlphas; // (level1, level2, level3, shadowStrength)
+    float    gToonPbrRampIntensity;
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -334,6 +337,7 @@ cbuffer CBPerObject : register(b0)
     float4   gToonPbrCuts;   // (cut1, cut2, cut3, strength)
     float4   gToonPbrLevels;
     float4   gToonPbrAlphas; // (level1, level2, level3, shadowStrength)
+    float    gToonPbrRampIntensity;
     
     // 아웃라인 파라미터 (모든 쉐이딩 모드에서 사용 가능, 16바이트 경계에서 시작)
     float3   gOutlineColor;
@@ -522,7 +526,7 @@ float ToonLevel(float n)
     return 0.1f;
 }
 
-float ToonStepEditable(float n, float3 cuts, float3 levels, float3 alphas, float strength, float blur)
+float ToonStepEditable(float n, float3 cuts, float3 levels, float3 alphas, float strength, float blur, float rampIntensity)
 {
     float c1 = saturate(cuts.x);
     float c2 = saturate(cuts.y);
@@ -541,6 +545,7 @@ float ToonStepEditable(float n, float3 cuts, float3 levels, float3 alphas, float
     float a3 = 1.0f;
 
     float t = saturate(strength);
+    float ramp = saturate(rampIntensity);
     if (blur > 0.5f)
     {
         float w = max(fwidth(n) * 2.0f, 0.02f);
@@ -554,6 +559,8 @@ float ToonStepEditable(float n, float3 cuts, float3 levels, float3 alphas, float
         float alpha = lerp(a0, a1, s1);
         alpha = lerp(alpha, a2, s2);
         alpha = lerp(alpha, a3, s3);
+        float darkMask = 1.0f - s1;
+        alpha *= (1.0f - ramp * darkMask);
         return lerp(n, level, t * alpha);
     }
 
@@ -565,6 +572,8 @@ float ToonStepEditable(float n, float3 cuts, float3 levels, float3 alphas, float
                   (n > c2) ? a2 :
                   (n > c1) ? a1 :
                              a0;
+    float darkMask = (n > c1) ? 0.0f : 1.0f;
+    alpha *= (1.0f - ramp * darkMask);
     return lerp(n, level, t * alpha);
 }
 
@@ -572,7 +581,7 @@ float ToonPbrNdotL(float n)
 {
     if (gShadingMode == 7)
     {
-         return ToonStepEditable(n, gToonPbrCuts.xyz, gToonPbrLevels.xyz, gToonPbrAlphas.xyz, gToonPbrCuts.w, gToonPbrLevels.w);
+         return ToonStepEditable(n, gToonPbrCuts.xyz, gToonPbrLevels.xyz, gToonPbrAlphas.xyz, gToonPbrCuts.w, gToonPbrLevels.w, gToonPbrRampIntensity);
     }
     return ToonLevel(n);
 }
@@ -779,13 +788,15 @@ float4 main(PSInput input) : SV_TARGET
         }
     }
 
-    // 전역 + 머티리얼 + ToonPBREditable 보정 강도 적용
-    float shadowStrength = saturate(gShadowStrength) * saturate(gToonPbrAlphas.w);
+    // 전역(0~1)을 더 강한 범위로 매핑 + 머티리얼 + ToonPBREditable 보정 강도 적용
+    const float kShadowStrengthMax = 12.0f;
+    float shadowStrength = saturate(gShadowStrength) * kShadowStrengthMax;
+    shadowStrength *= saturate(gToonPbrAlphas.w);
     if (gShadingMode == 7)
     {
         shadowStrength *= saturate(gToonShadowStrength);
     }
-    shadow = lerp(1.0f, shadow, shadowStrength);
+    shadow = saturate(lerp(1.0f, shadow, shadowStrength));
 
     totalDiffuse  *= shadow;
     totalSpecular *= shadow;


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #36 

## 📝 작업 내용
- [x] 모니터에 따라 그림자가 잘 안보이는 현상을 없애기
- [x] 그림자 수치와 그림자 퀄리티를 선택할 수 있게 하기
- [x] 툰 pbr에서의 그림자 제거해보기 툰 램프 말하는거임
- [x] AgX 톤매핑을 흉내내서 블렌더와 같은 색감을 만들기
- [x] 최소한의 그림자 관련 퀄리티 설정과 그림자 강도를 설정할 수 있게 하기
- [x] 빛 방향을 조절할때 더 쉽게 하게 하기

## 🔬 테스트 방법 (없으면 삭제)
- 

## 📸 스크린샷 (선택)


<img width="2560" height="1540" alt="블렌더" src="https://github.com/user-attachments/assets/d5178f06-214a-4d00-ad2b-d5458eb368d2" />


<img width="2560" height="1540" alt="엔진" src="https://github.com/user-attachments/assets/4482508d-9d68-4ea9-ad40-14f5a9aa9ee7" />

<img width="2002" height="1194" alt="image" src="https://github.com/user-attachments/assets/fd8b2a5c-494d-4362-b4f6-3d2f4219bb3e" />


## ✅ 체크리스트
- [x] 빌드가 에러 없이 정상적으로 되나요?
- [x] 불필요한 로그나 주석을 제거했나요?
- [x] 코딩 컨벤션을 지켰나요?