### PR TITLE
#22 에디터 편의기능 추가

### DIFF
--- a/Assets/Scenes/Camera/3DCameraScene.scene
+++ b/Assets/Scenes/Camera/3DCameraScene.scene
@@ -6,12 +6,13 @@
                     "enabled": true,
                     "name": "SceneSwitchExample",
                     "props": {
-                        "m_targetName1": "",
-                        "m_targetName2": ""
+                        "targetSceneA": "Assets/Scenes/SceneChange/SceneChange2.scene",
+                        "targetSceneB": ""
                     }
                 }
             ],
             "Transform": {
+                "enabled": true,
                 "position": {
                     "x": -10.624564170837402,
                     "y": 7.713817119598389,
@@ -26,19 +27,24 @@
                     "x": 1.0,
                     "y": 0.9999999403953552,
                     "z": 0.9999999403953552
-                }
+                },
+                "visible": true
             },
-            "id": 68
+            "guid": "15854061279726717599"
         },
         {
             "Material": {
                 "albedoTexturePath": "Cooked/Textures/Rapi/Rapi_Diffuse_embedded0.alice",
+                "alpha": 1.0,
+                "ambientOcclusion": 1.0,
                 "assetPath": "Assets/Materials/Rapi_0.mat",
                 "color": {
                     "x": 0.8957529067993164,
                     "y": 0.8957529067993164,
                     "z": 0.8957529067993164
                 },
+                "envDiffuseStrength": 1.0,
+                "envSpecularStrength": 1.0,
                 "metalness": 0.0,
                 "normalStrength": 5.0,
                 "outlineColor": {
@@ -46,9 +52,24 @@
                     "y": 0.0,
                     "z": 0.0
                 },
-                "outlineWidth": 0.14000000059604645,
+                "outlineWidth": 0.029999999329447746,
                 "roughness": 0.5,
-                "shadingMode": -1
+                "shadingMode": -1,
+                "shadowStrength": 1.0,
+                "toonPbrBlur": false,
+                "toonPbrCut1": 0.20000000298023224,
+                "toonPbrCut2": 0.5,
+                "toonPbrCut3": 0.949999988079071,
+                "toonPbrLevel1": 0.10000000149011612,
+                "toonPbrLevel1Alpha": 1.0,
+                "toonPbrLevel2": 0.4000000059604645,
+                "toonPbrLevel2Alpha": 1.0,
+                "toonPbrLevel3": 0.699999988079071,
+                "toonPbrLevel3Alpha": 1.0,
+                "toonPbrRampIntensity": 0.0,
+                "toonPbrStrength": 1.0,
+                "toonSelfShadowStrength": 1.0,
+                "transparent": false
             },
             "Scripts": [
                 {
@@ -65,7 +86,7 @@
                 "clipIndex": 0,
                 "playing": true,
                 "speed": 1.0,
-                "timeSec": 60.922822618624195
+                "timeSec": 297.2248766332632
             },
             "SkinnedMesh": {
                 "boneCount": 180,
@@ -73,6 +94,7 @@
                 "meshAssetPath": "Rapi"
             },
             "Transform": {
+                "enabled": true,
                 "position": {
                     "x": -1.84263014793396,
                     "y": 0.0,
@@ -84,20 +106,21 @@
                     "z": 0.0
                 },
                 "scale": {
-                    "x": 0.05000000074505806,
-                    "y": 0.05000000074505806,
-                    "z": 0.05000000074505806
-                }
+                    "x": 0.019999999552965164,
+                    "y": 0.019999999552965164,
+                    "z": 0.019999999552965164
+                },
+                "visible": true
             },
-            "id": 69,
+            "guid": "3247504205382143632",
             "name": "Rapi"
         },
         {
             "Camera": {
+                "FOV": 45.0,
+                "Far Plane": 1000.0,
+                "Near Plane": 0.10000000149011612,
                 "aspectOverride": 0.0,
-                "farPlane": 5000.0,
-                "fovYRad": 1.047196626663208,
-                "nearPlane": 0.10000000149011612,
                 "primary": true,
                 "useAspectOverride": false
             },
@@ -130,6 +153,7 @@
                 "fastTurnYawThresholdDeg": 90.0,
                 "fovDamping": 6.0,
                 "heightOffset": 8.569999694824219,
+                "invertMouse": false,
                 "lockOnAngleWeight": 1.5,
                 "lockOnDistance": 24.0,
                 "lockOnFovDeg": 55.0,
@@ -193,12 +217,16 @@
             },
             "Material": {
                 "albedoTexturePath": "",
+                "alpha": 1.0,
+                "ambientOcclusion": 1.0,
                 "assetPath": "",
                 "color": {
                     "x": 1.0,
                     "y": 0.0,
                     "z": 0.0
                 },
+                "envDiffuseStrength": 1.0,
+                "envSpecularStrength": 1.0,
                 "metalness": 0.0,
                 "normalStrength": 1.0,
                 "outlineColor": {
@@ -208,7 +236,22 @@
                 },
                 "outlineWidth": 0.009999999776482582,
                 "roughness": 0.5,
-                "shadingMode": -1
+                "shadingMode": -1,
+                "shadowStrength": 1.0,
+                "toonPbrBlur": false,
+                "toonPbrCut1": 0.20000000298023224,
+                "toonPbrCut2": 0.5,
+                "toonPbrCut3": 0.949999988079071,
+                "toonPbrLevel1": 0.10000000149011612,
+                "toonPbrLevel1Alpha": 1.0,
+                "toonPbrLevel2": 0.4000000059604645,
+                "toonPbrLevel2Alpha": 1.0,
+                "toonPbrLevel3": 0.699999988079071,
+                "toonPbrLevel3Alpha": 1.0,
+                "toonPbrRampIntensity": 0.0,
+                "toonPbrStrength": 1.0,
+                "toonSelfShadowStrength": 1.0,
+                "transparent": false
             },
             "Scripts": [
                 {
@@ -248,6 +291,7 @@
                 }
             ],
             "Transform": {
+                "enabled": true,
                 "position": {
                     "x": -8.49720287322998,
                     "y": 21.751176834106445,
@@ -262,20 +306,25 @@
                     "x": 1.0,
                     "y": 1.0,
                     "z": 1.0
-                }
+                },
+                "visible": true
             },
-            "id": 70,
+            "guid": "3117629515633492951",
             "name": "MainCamera"
         },
         {
             "Material": {
                 "albedoTexturePath": "",
+                "alpha": 1.0,
+                "ambientOcclusion": 1.0,
                 "assetPath": "",
                 "color": {
                     "x": 1.0,
                     "y": 1.0,
                     "z": 1.0
                 },
+                "envDiffuseStrength": 1.0,
+                "envSpecularStrength": 1.0,
                 "metalness": 0.0,
                 "normalStrength": 1.0,
                 "outlineColor": {
@@ -285,9 +334,25 @@
                 },
                 "outlineWidth": -5.079999923706055,
                 "roughness": 1.0,
-                "shadingMode": -1
+                "shadingMode": -1,
+                "shadowStrength": 1.0,
+                "toonPbrBlur": false,
+                "toonPbrCut1": 0.20000000298023224,
+                "toonPbrCut2": 0.5,
+                "toonPbrCut3": 0.949999988079071,
+                "toonPbrLevel1": 0.10000000149011612,
+                "toonPbrLevel1Alpha": 1.0,
+                "toonPbrLevel2": 0.4000000059604645,
+                "toonPbrLevel2Alpha": 1.0,
+                "toonPbrLevel3": 0.699999988079071,
+                "toonPbrLevel3Alpha": 1.0,
+                "toonPbrRampIntensity": 0.0,
+                "toonPbrStrength": 1.0,
+                "toonSelfShadowStrength": 1.0,
+                "transparent": false
             },
             "Transform": {
+                "enabled": true,
                 "position": {
                     "x": 0.18812775611877441,
                     "y": -1.5509624481201172,
@@ -302,20 +367,25 @@
                     "x": 150.4550018310547,
                     "y": 1.0,
                     "z": 118.77100372314453
-                }
+                },
+                "visible": true
             },
-            "id": 71,
+            "guid": "7071510380385917387",
             "name": "Ground"
         },
         {
             "Material": {
                 "albedoTexturePath": "",
+                "alpha": 1.0,
+                "ambientOcclusion": 1.0,
                 "assetPath": "",
                 "color": {
                     "x": 1.0,
                     "y": 1.0,
                     "z": 1.0
                 },
+                "envDiffuseStrength": 1.0,
+                "envSpecularStrength": 1.0,
                 "metalness": 1.0,
                 "normalStrength": 1.0,
                 "outlineColor": {
@@ -325,7 +395,22 @@
                 },
                 "outlineWidth": 0.009999999776482582,
                 "roughness": 0.0,
-                "shadingMode": -1
+                "shadingMode": -1,
+                "shadowStrength": 1.0,
+                "toonPbrBlur": false,
+                "toonPbrCut1": 0.20000000298023224,
+                "toonPbrCut2": 0.5,
+                "toonPbrCut3": 0.949999988079071,
+                "toonPbrLevel1": 0.10000000149011612,
+                "toonPbrLevel1Alpha": 1.0,
+                "toonPbrLevel2": 0.4000000059604645,
+                "toonPbrLevel2Alpha": 1.0,
+                "toonPbrLevel3": 0.699999988079071,
+                "toonPbrLevel3Alpha": 1.0,
+                "toonPbrRampIntensity": 0.0,
+                "toonPbrStrength": 1.0,
+                "toonSelfShadowStrength": 1.0,
+                "transparent": false
             },
             "Scripts": [
                 {
@@ -339,6 +424,7 @@
                 }
             ],
             "Transform": {
+                "enabled": true,
                 "position": {
                     "x": 4.098037242889404,
                     "y": 8.976366996765137,
@@ -353,20 +439,25 @@
                     "x": 1.219151258468628,
                     "y": 1.219151258468628,
                     "z": 1.219151258468628
-                }
+                },
+                "visible": true
             },
-            "id": 72,
+            "guid": "4870920414070202551",
             "name": "Entity5"
         },
         {
             "Material": {
                 "albedoTexturePath": "Cooked/Textures/Zombie_Run/Zombie_Run_Diffuse_embedded5.alice",
+                "alpha": 1.0,
+                "ambientOcclusion": 1.0,
                 "assetPath": "Assets/Materials/Zombie_Run_0.mat",
                 "color": {
                     "x": 0.699999988079071,
                     "y": 0.699999988079071,
                     "z": 0.699999988079071
                 },
+                "envDiffuseStrength": 1.0,
+                "envSpecularStrength": 1.0,
                 "metalness": 0.0,
                 "normalStrength": 1.0,
                 "outlineColor": {
@@ -376,13 +467,28 @@
                 },
                 "outlineWidth": 0.009999999776482582,
                 "roughness": 0.5,
-                "shadingMode": -1
+                "shadingMode": -1,
+                "shadowStrength": 1.0,
+                "toonPbrBlur": false,
+                "toonPbrCut1": 0.20000000298023224,
+                "toonPbrCut2": 0.5,
+                "toonPbrCut3": 0.949999988079071,
+                "toonPbrLevel1": 0.10000000149011612,
+                "toonPbrLevel1Alpha": 1.0,
+                "toonPbrLevel2": 0.4000000059604645,
+                "toonPbrLevel2Alpha": 1.0,
+                "toonPbrLevel3": 0.699999988079071,
+                "toonPbrLevel3Alpha": 1.0,
+                "toonPbrRampIntensity": 0.0,
+                "toonPbrStrength": 1.0,
+                "toonSelfShadowStrength": 1.0,
+                "transparent": false
             },
             "SkinnedAnimation": {
                 "clipIndex": 0,
                 "playing": true,
                 "speed": 1.0,
-                "timeSec": 2350.485586215509
+                "timeSec": 2586.787640230148
             },
             "SkinnedMesh": {
                 "boneCount": 67,
@@ -390,6 +496,7 @@
                 "meshAssetPath": "Zombie_Run"
             },
             "Transform": {
+                "enabled": true,
                 "position": {
                     "x": -15.32771110534668,
                     "y": 0.0,
@@ -404,29 +511,49 @@
                     "x": 0.07999999821186066,
                     "y": 0.07999999821186066,
                     "z": 0.07999999821186066
-                }
+                },
+                "visible": true
             },
-            "id": 73
+            "guid": "10975993849492367656"
         },
         {
             "Material": {
                 "albedoTexturePath": "Cooked/Textures/Tree/Tree_Diffuse_embedded7.alice",
+                "alpha": 1.0,
+                "ambientOcclusion": 1.0,
                 "assetPath": "Assets/Materials/Tree_0.mat",
                 "color": {
                     "x": 0.699999988079071,
                     "y": 0.699999988079071,
                     "z": 0.699999988079071
                 },
+                "envDiffuseStrength": 1.0,
+                "envSpecularStrength": 1.0,
                 "metalness": 0.0,
                 "normalStrength": 1.0,
                 "outlineColor": {
-                    "x": 0.0,
-                    "y": 0.0,
-                    "z": 0.0
+                    "x": 0.6571773290634155,
+                    "y": 0.12692120671272278,
+                    "z": 0.9961389899253845
                 },
-                "outlineWidth": -0.699999988079071,
+                "outlineWidth": 0.019999999552965164,
                 "roughness": 0.5,
-                "shadingMode": -1
+                "shadingMode": -1,
+                "shadowStrength": 1.0,
+                "toonPbrBlur": false,
+                "toonPbrCut1": 0.20000000298023224,
+                "toonPbrCut2": 0.5,
+                "toonPbrCut3": 0.949999988079071,
+                "toonPbrLevel1": 0.10000000149011612,
+                "toonPbrLevel1Alpha": 1.0,
+                "toonPbrLevel2": 0.4000000059604645,
+                "toonPbrLevel2Alpha": 1.0,
+                "toonPbrLevel3": 0.699999988079071,
+                "toonPbrLevel3Alpha": 1.0,
+                "toonPbrRampIntensity": 0.0,
+                "toonPbrStrength": 1.0,
+                "toonSelfShadowStrength": 1.0,
+                "transparent": false
             },
             "SkinnedAnimation": {
                 "clipIndex": 0,
@@ -440,6 +567,7 @@
                 "meshAssetPath": "Tree"
             },
             "Transform": {
+                "enabled": true,
                 "position": {
                     "x": 16.755603790283203,
                     "y": 0.0,
@@ -454,11 +582,50 @@
                     "x": 5.0,
                     "y": 5.0,
                     "z": 5.0
-                }
+                },
+                "visible": true
             },
-            "id": 74
+            "guid": "12443456840186684616"
         },
         {
+            "Material": {
+                "albedoTexturePath": "",
+                "alpha": 1.0,
+                "ambientOcclusion": 1.0,
+                "assetPath": "",
+                "color": {
+                    "x": 0.699999988079071,
+                    "y": 0.699999988079071,
+                    "z": 0.699999988079071
+                },
+                "envDiffuseStrength": 1.0,
+                "envSpecularStrength": 1.0,
+                "metalness": 0.0,
+                "normalStrength": 1.0,
+                "outlineColor": {
+                    "x": 0.0,
+                    "y": 1.0,
+                    "z": 0.9189188480377197
+                },
+                "outlineWidth": 0.07000000029802322,
+                "roughness": 0.5,
+                "shadingMode": -1,
+                "shadowStrength": 1.0,
+                "toonPbrBlur": false,
+                "toonPbrCut1": 0.20000000298023224,
+                "toonPbrCut2": 0.5,
+                "toonPbrCut3": 0.949999988079071,
+                "toonPbrLevel1": 0.10000000149011612,
+                "toonPbrLevel1Alpha": 1.0,
+                "toonPbrLevel2": 0.4000000059604645,
+                "toonPbrLevel2Alpha": 1.0,
+                "toonPbrLevel3": 0.699999988079071,
+                "toonPbrLevel3Alpha": 1.0,
+                "toonPbrRampIntensity": 0.0,
+                "toonPbrStrength": 1.0,
+                "toonSelfShadowStrength": 1.0,
+                "transparent": false
+            },
             "SkinnedAnimation": {
                 "clipIndex": 0,
                 "playing": true,
@@ -471,6 +638,7 @@
                 "meshAssetPath": "zeldaPosed001"
             },
             "Transform": {
+                "enabled": true,
                 "position": {
                     "x": 19.82941436767578,
                     "y": 0.0,
@@ -482,12 +650,13 @@
                     "z": 0.0
                 },
                 "scale": {
-                    "x": 0.04000000283122063,
-                    "y": 0.03999999910593033,
-                    "z": 0.04000000283122063
-                }
+                    "x": 0.05000000074505806,
+                    "y": 0.05000000074505806,
+                    "z": 0.05000000074505806
+                },
+                "visible": true
             },
-            "id": 75,
+            "guid": "4107798903806519686",
             "name": "Enemy"
         },
         {
@@ -495,7 +664,7 @@
                 "clipIndex": 0,
                 "playing": true,
                 "speed": 1.0,
-                "timeSec": 2255.279237420531
+                "timeSec": 2491.58129143517
             },
             "SkinnedMesh": {
                 "boneCount": 16,
@@ -503,6 +672,7 @@
                 "meshAssetPath": "BoxHuman"
             },
             "Transform": {
+                "enabled": true,
                 "position": {
                     "x": -18.724641799926758,
                     "y": 0.0,
@@ -517,20 +687,22 @@
                     "x": 0.029999999329447746,
                     "y": 0.029999999329447746,
                     "z": 0.029999999329447746
-                }
+                },
+                "visible": true
             },
-            "id": 76
+            "guid": "6246121460388624064"
         },
         {
             "Camera": {
+                "FOV": 45.0,
+                "Far Plane": 1000.0,
+                "Near Plane": 0.10000000149011612,
                 "aspectOverride": 0.0,
-                "farPlane": 5000.0,
-                "fovYRad": 0.7853981852531433,
-                "nearPlane": 0.10000000149011612,
                 "primary": false,
                 "useAspectOverride": false
             },
             "Transform": {
+                "enabled": true,
                 "position": {
                     "x": 19.534574508666992,
                     "y": 9.538835525512695,
@@ -545,21 +717,23 @@
                     "x": 1.0,
                     "y": 1.0,
                     "z": 1.0
-                }
+                },
+                "visible": true
             },
-            "id": 77,
+            "guid": "7647557469715538969",
             "name": "Camera1"
         },
         {
             "Camera": {
+                "FOV": 45.0,
+                "Far Plane": 1000.0,
+                "Near Plane": 0.10000000149011612,
                 "aspectOverride": 0.0,
-                "farPlane": 5000.0,
-                "fovYRad": 0.7853981852531433,
-                "nearPlane": 0.10000000149011612,
                 "primary": false,
                 "useAspectOverride": false
             },
             "Transform": {
+                "enabled": true,
                 "position": {
                     "x": 5.509352684020996,
                     "y": 5.486000061035156,
@@ -574,21 +748,23 @@
                     "x": 0.9999995231628418,
                     "y": 0.9999999403953552,
                     "z": 0.9999999403953552
-                }
+                },
+                "visible": true
             },
-            "id": 78,
+            "guid": "7897188279278773419",
             "name": "Camera2"
         },
         {
             "Camera": {
+                "FOV": 45.0,
+                "Far Plane": 1000.0,
+                "Near Plane": 0.10000000149011612,
                 "aspectOverride": 0.0,
-                "farPlane": 5000.0,
-                "fovYRad": 0.7853981852531433,
-                "nearPlane": 0.10000000149011612,
                 "primary": false,
                 "useAspectOverride": false
             },
             "Transform": {
+                "enabled": true,
                 "position": {
                     "x": -19.898765563964844,
                     "y": 5.294197082519531,
@@ -603,21 +779,23 @@
                     "x": 1.0,
                     "y": 1.0,
                     "z": 1.0
-                }
+                },
+                "visible": true
             },
-            "id": 79,
+            "guid": "3763756653405547499",
             "name": "Camera3"
         },
         {
             "Camera": {
+                "FOV": 45.0,
+                "Far Plane": 1000.0,
+                "Near Plane": 0.10000000149011612,
                 "aspectOverride": 0.0,
-                "farPlane": 5000.0,
-                "fovYRad": 0.7853981852531433,
-                "nearPlane": 0.10000000149011612,
                 "primary": false,
                 "useAspectOverride": false
             },
             "Transform": {
+                "enabled": true,
                 "position": {
                     "x": 34.33367156982422,
                     "y": 7.49192476272583,
@@ -632,21 +810,23 @@
                     "x": 0.9999999403953552,
                     "y": 1.0,
                     "z": 1.0
-                }
+                },
+                "visible": true
             },
-            "id": 80,
+            "guid": "11468521462846839239",
             "name": "Camera4"
         },
         {
             "Camera": {
+                "FOV": 45.0,
+                "Far Plane": 1000.0,
+                "Near Plane": 0.10000000149011612,
                 "aspectOverride": 0.0,
-                "farPlane": 5000.0,
-                "fovYRad": 0.7853981852531433,
-                "nearPlane": 0.10000000149011612,
                 "primary": false,
                 "useAspectOverride": false
             },
             "Transform": {
+                "enabled": true,
                 "position": {
                     "x": -11.619190216064453,
                     "y": 8.984113693237305,
@@ -661,20 +841,25 @@
                     "x": 1.0,
                     "y": 1.0,
                     "z": 1.0
-                }
+                },
+                "visible": true
             },
-            "id": 81,
+            "guid": "11140710190559784894",
             "name": "Camera5"
         },
         {
             "Material": {
                 "albedoTexturePath": "",
+                "alpha": 1.0,
+                "ambientOcclusion": 1.0,
                 "assetPath": "Assets/Materials/Alice_0.mat",
                 "color": {
                     "x": 0.699999988079071,
                     "y": 0.699999988079071,
                     "z": 0.699999988079071
                 },
+                "envDiffuseStrength": 1.0,
+                "envSpecularStrength": 1.0,
                 "metalness": 0.0,
                 "normalStrength": 1.906999945640564,
                 "outlineColor": {
@@ -684,13 +869,28 @@
                 },
                 "outlineWidth": 0.0010000000474974513,
                 "roughness": 0.5,
-                "shadingMode": -1
+                "shadingMode": -1,
+                "shadowStrength": 1.0,
+                "toonPbrBlur": false,
+                "toonPbrCut1": 0.20000000298023224,
+                "toonPbrCut2": 0.5,
+                "toonPbrCut3": 0.949999988079071,
+                "toonPbrLevel1": 0.10000000149011612,
+                "toonPbrLevel1Alpha": 1.0,
+                "toonPbrLevel2": 0.4000000059604645,
+                "toonPbrLevel2Alpha": 1.0,
+                "toonPbrLevel3": 0.699999988079071,
+                "toonPbrLevel3Alpha": 1.0,
+                "toonPbrRampIntensity": 0.0,
+                "toonPbrStrength": 1.0,
+                "toonSelfShadowStrength": 1.0,
+                "transparent": false
             },
             "SkinnedAnimation": {
                 "clipIndex": 4,
                 "playing": true,
                 "speed": 1.0,
-                "timeSec": 526.0881495517679
+                "timeSec": 762.3902035664069
             },
             "SkinnedMesh": {
                 "boneCount": 248,
@@ -698,6 +898,7 @@
                 "meshAssetPath": "Alice"
             },
             "Transform": {
+                "enabled": true,
                 "position": {
                     "x": 0.0,
                     "y": 0.0,
@@ -712,19 +913,24 @@
                     "x": 1.0,
                     "y": 1.0,
                     "z": 1.0
-                }
+                },
+                "visible": true
             },
-            "id": 82
+            "guid": "12108789652549811598"
         },
         {
             "Material": {
                 "albedoTexturePath": "",
+                "alpha": 1.0,
+                "ambientOcclusion": 1.0,
                 "assetPath": "Assets/Materials/tile0120_0.mat",
                 "color": {
                     "x": 0.699999988079071,
                     "y": 0.699999988079071,
                     "z": 0.699999988079071
                 },
+                "envDiffuseStrength": 1.0,
+                "envSpecularStrength": 1.0,
                 "metalness": 0.0,
                 "normalStrength": 0.0,
                 "outlineColor": {
@@ -734,7 +940,22 @@
                 },
                 "outlineWidth": 0.009999999776482582,
                 "roughness": 0.5,
-                "shadingMode": -1
+                "shadingMode": -1,
+                "shadowStrength": 1.0,
+                "toonPbrBlur": false,
+                "toonPbrCut1": 0.20000000298023224,
+                "toonPbrCut2": 0.5,
+                "toonPbrCut3": 0.949999988079071,
+                "toonPbrLevel1": 0.10000000149011612,
+                "toonPbrLevel1Alpha": 1.0,
+                "toonPbrLevel2": 0.4000000059604645,
+                "toonPbrLevel2Alpha": 1.0,
+                "toonPbrLevel3": 0.699999988079071,
+                "toonPbrLevel3Alpha": 1.0,
+                "toonPbrRampIntensity": 0.0,
+                "toonPbrStrength": 1.0,
+                "toonSelfShadowStrength": 1.0,
+                "transparent": false
             },
             "SkinnedAnimation": {
                 "clipIndex": 0,
@@ -748,6 +969,7 @@
                 "meshAssetPath": "tile0120"
             },
             "Transform": {
+                "enabled": true,
                 "position": {
                     "x": 0.0,
                     "y": 0.0,
@@ -762,10 +984,12 @@
                     "x": 1.0,
                     "y": 1.0,
                     "z": 1.0
-                }
+                },
+                "visible": true
             },
-            "id": 83
+            "guid": "8022266422418442521"
         }
     ],
+    "sceneName": "3DCameraScene",
     "version": 1
 }

--- a/Assets/Scenes/SceneChange/SceneChange2.scene
+++ b/Assets/Scenes/SceneChange/SceneChange2.scene
@@ -3,6 +3,7 @@
         {
             "Material": {
                 "albedoTexturePath": "",
+                "alpha": 1.0,
                 "ambientOcclusion": 1.0,
                 "assetPath": "",
                 "color": {
@@ -10,6 +11,8 @@
                     "y": 0.038610219955444336,
                     "z": 1.0
                 },
+                "envDiffuseStrength": 1.0,
+                "envSpecularStrength": 1.0,
                 "metalness": 1.0,
                 "normalStrength": 1.0,
                 "outlineColor": {
@@ -20,14 +23,20 @@
                 "outlineWidth": -0.15000000596046448,
                 "roughness": 0.0,
                 "shadingMode": -1,
+                "shadowStrength": 1.0,
                 "toonPbrBlur": false,
                 "toonPbrCut1": 0.20000000298023224,
                 "toonPbrCut2": 0.5,
                 "toonPbrCut3": 0.949999988079071,
                 "toonPbrLevel1": 0.10000000149011612,
+                "toonPbrLevel1Alpha": 1.0,
                 "toonPbrLevel2": 0.4000000059604645,
+                "toonPbrLevel2Alpha": 1.0,
                 "toonPbrLevel3": 0.699999988079071,
+                "toonPbrLevel3Alpha": 1.0,
+                "toonPbrRampIntensity": 0.0,
                 "toonPbrStrength": 1.0,
+                "toonSelfShadowStrength": 1.0,
                 "transparent": false
             },
             "Transform": {
@@ -46,13 +55,15 @@
                     "x": 1.0,
                     "y": 1.0,
                     "z": 1.0
-                }
+                },
+                "visible": true
             },
             "guid": "8391382352650265924"
         },
         {
             "Material": {
                 "albedoTexturePath": "",
+                "alpha": 1.0,
                 "ambientOcclusion": 1.0,
                 "assetPath": "",
                 "color": {
@@ -60,6 +71,8 @@
                     "y": 0.15444016456604004,
                     "z": 1.0
                 },
+                "envDiffuseStrength": 1.0,
+                "envSpecularStrength": 1.0,
                 "metalness": 0.5049999952316284,
                 "normalStrength": 1.0,
                 "outlineColor": {
@@ -70,14 +83,20 @@
                 "outlineWidth": -0.5299999713897705,
                 "roughness": 0.0,
                 "shadingMode": -1,
+                "shadowStrength": 1.0,
                 "toonPbrBlur": false,
                 "toonPbrCut1": 0.20000000298023224,
                 "toonPbrCut2": 0.5,
                 "toonPbrCut3": 0.949999988079071,
                 "toonPbrLevel1": 0.10000000149011612,
+                "toonPbrLevel1Alpha": 1.0,
                 "toonPbrLevel2": 0.4000000059604645,
+                "toonPbrLevel2Alpha": 1.0,
                 "toonPbrLevel3": 0.699999988079071,
+                "toonPbrLevel3Alpha": 1.0,
+                "toonPbrRampIntensity": 0.0,
                 "toonPbrStrength": 1.0,
+                "toonSelfShadowStrength": 1.0,
                 "transparent": false
             },
             "Transform": {
@@ -96,7 +115,8 @@
                     "x": 47.62660598754883,
                     "y": 0.5068082213401794,
                     "z": 20.796457290649414
-                }
+                },
+                "visible": true
             },
             "guid": "10678209540132580737",
             "name": "Entity2"
@@ -107,7 +127,7 @@
                     "enabled": true,
                     "name": "SceneSwitchExample",
                     "props": {
-                        "targetSceneA": "Assets/Scenes/SceneChange/SceneChange1.scene",
+                        "targetSceneA": "Assets/Scenes/Camera/3DCameraScene.scene",
                         "targetSceneB": ""
                     }
                 }
@@ -128,7 +148,8 @@
                     "x": 1.0,
                     "y": 1.0,
                     "z": 1.0
-                }
+                },
+                "visible": true
             },
             "guid": "12627764042847929771",
             "name": "GameObject3"
@@ -158,7 +179,8 @@
                     "x": 1.0,
                     "y": 1.0,
                     "z": 1.0
-                }
+                },
+                "visible": true
             },
             "guid": "3636309116445919589",
             "name": "Camera1"

--- a/Assets/Startup/Preload.json
+++ b/Assets/Startup/Preload.json
@@ -1,0 +1,13 @@
+{
+    "preload": [
+        "Resource/Icon/AliceBanner.png",
+        "Resource/Fonts/NotoSansKR-Regular.ttf",
+        "Assets/Fbx/Alice.fbxasset",
+        "Assets/Fbx/Rapi.fbxasset",
+        "Assets/Fbx/Tia_Animaition.fbxasset",
+        "Assets/Fbx/zeldaPosed001.fbxasset",
+        "Assets/Fbx/Zombie_Run.fbxasset",
+        "Assets/Fbx/BoxHuman.fbxasset",
+        "Assets/Fbx/Tree.fbxasset"
+    ]
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,7 @@ set(ENGINE_SOURCES
     ${ALICE_SRC_DIR}/Editor/UI/AliceUIFactory.cpp
     ${ALICE_SRC_DIR}/Editor/AssetEditors/MaterialAssetEditor.cpp
     ${ALICE_SRC_DIR}/Editor/AssetEditors/UICurveAssetEditor.cpp
+    ${ALICE_SRC_DIR}/Editor/AssetEditors/PreloadAssetEditor.cpp
 
     # 코어(ECS 스타일)
     ${ALICE_SRC_DIR}/Runtime/ECS/World.cpp
@@ -159,6 +160,7 @@ set(ENGINE_SOURCES
     ${ALICE_SRC_DIR}/Runtime/Importing/FbxSkeleton.cpp
     ${ALICE_SRC_DIR}/Runtime/Importing/FbxGeometry.cpp
     ${ALICE_SRC_DIR}/Runtime/Importing/FbxAnimation.cpp
+    ${ALICE_SRC_DIR}/Runtime/Importing/FbxAsset.cpp
 
     # AnimBlueprint
     ${ALICE_SRC_DIR}/Runtime/Gameplay/Animation/AnimBlueprintAsset.cpp
@@ -301,6 +303,7 @@ set(ENGINE_HEADERS
     ${ALICE_SRC_DIR}/Runtime/Importing/FbxTypes.h
     ${ALICE_SRC_DIR}/Runtime/Importing/FbxGeometry.h
     ${ALICE_SRC_DIR}/Runtime/Importing/FbxAnimation.h
+    ${ALICE_SRC_DIR}/Runtime/Importing/FbxAsset.h
 
     # 렌더링 계층
     ${ALICE_SRC_DIR}/Runtime/Rendering/Camera.h
@@ -430,13 +433,11 @@ set(APP_COMMON_SOURCES
     ${ALICE_SRC_DIR}/Samples/Scenes/SampleScene.cpp
     ${ALICE_SRC_DIR}/Samples/Sandbox/DelayLoadHook.cpp
     ${ALICE_SRC_DIR}/Runtime/Importing/FbxImporter.cpp
-    ${ALICE_SRC_DIR}/Runtime/Importing/FbxAsset.cpp
 )
 
 set(APP_HEADERS
     ${ALICE_SRC_DIR}/Samples/Scenes/SampleScene.h
     ${ALICE_SRC_DIR}/Runtime/Importing/FbxImporter.h
-    ${ALICE_SRC_DIR}/Runtime/Importing/FbxAsset.h
     ${ALICE_SRC_DIR}/Runtime/Gameplay/Animation/SkinnedMeshSystem.h
     ${ALICE_SRC_DIR}/Runtime/Engine/AdvancedAnimSystem.h
 )

--- a/Engine/src/Editor/AssetEditors/PreloadAssetEditor.cpp
+++ b/Engine/src/Editor/AssetEditors/PreloadAssetEditor.cpp
@@ -1,0 +1,601 @@
+#include "Editor/Core/EditorCore.h"
+#include "Editor/Core/EditorUIState.h"
+
+#include "Runtime/Foundation/Logger.h"
+#include "Runtime/Resources/ResourceManager.h"
+
+#include "ThirdParty/json/json.hpp"
+
+#include "imgui.h"
+
+#include <commdlg.h>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+#include <algorithm>
+#include <cctype>
+
+namespace Alice
+{
+	namespace
+	{
+		std::string ToLowerAscii(std::string s)
+		{
+			for (char& c : s)
+				c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+			return s;
+		}
+
+		std::string TrimAscii(const std::string& s)
+		{
+			size_t start = 0;
+			while (start < s.size() && std::isspace(static_cast<unsigned char>(s[start])))
+				++start;
+			size_t end = s.size();
+			while (end > start && std::isspace(static_cast<unsigned char>(s[end - 1])))
+				--end;
+			return s.substr(start, end - start);
+		}
+
+		std::string NormalizeLogicalPath(const std::string& s)
+		{
+			std::string temp = s;
+			std::replace(temp.begin(), temp.end(), '\\', '/');
+			if (temp.rfind("./", 0) == 0)
+				temp = temp.substr(2);
+			std::filesystem::path p(temp);
+			std::string normalized = p.lexically_normal().generic_string();
+			if (normalized.rfind("./", 0) == 0)
+				normalized = normalized.substr(2);
+			return normalized;
+		}
+
+		bool HasParentTraversal(const std::string& s)
+		{
+			std::filesystem::path p(s);
+			for (const auto& part : p)
+			{
+				if (part == "..")
+					return true;
+			}
+			return false;
+		}
+
+		bool IsAllowedLogicalPath(const std::string& s)
+		{
+			const std::string lower = ToLowerAscii(s);
+			return lower.rfind("assets/", 0) == 0 ||
+				lower.rfind("resource/", 0) == 0 ||
+				lower.rfind("cooked/", 0) == 0;
+		}
+
+		std::filesystem::path GetProjectRoot()
+		{
+			wchar_t exePathW[MAX_PATH] = {};
+			GetModuleFileNameW(nullptr, exePathW, MAX_PATH);
+			std::filesystem::path exeDir = std::filesystem::path(exePathW).parent_path();
+			return exeDir.parent_path().parent_path().parent_path();
+		}
+
+		bool TryMakeLogicalPath(const std::filesystem::path& input, std::string& outLogical)
+		{
+			outLogical.clear();
+			if (input.empty())
+				return false;
+
+			if (input.is_absolute())
+			{
+				// Resource/... 우선 변환
+				std::filesystem::path logical = ResourceManager::NormalizeResourcePathAbsoluteToLogical(input);
+				if (!logical.empty() && !logical.is_absolute())
+				{
+					std::string normalized = NormalizeLogicalPath(logical.generic_string());
+					if (!HasParentTraversal(normalized) && IsAllowedLogicalPath(normalized))
+					{
+						outLogical = normalized;
+						return true;
+					}
+				}
+
+				// 프로젝트 루트 기준 상대 경로
+				std::error_code ec;
+				const std::filesystem::path projectRoot = GetProjectRoot();
+				const std::filesystem::path rel = std::filesystem::relative(input, projectRoot, ec);
+				if (!ec && !rel.empty())
+				{
+					std::string normalized = NormalizeLogicalPath(rel.generic_string());
+					if (!HasParentTraversal(normalized) && IsAllowedLogicalPath(normalized))
+					{
+						outLogical = normalized;
+						return true;
+					}
+				}
+
+				return false;
+			}
+
+			{
+				std::string normalized = NormalizeLogicalPath(input.generic_string());
+				if (!HasParentTraversal(normalized) && IsAllowedLogicalPath(normalized))
+				{
+					outLogical = normalized;
+					return true;
+				}
+			}
+			return false;
+		}
+
+		bool LoadPreloadJsonFile(const std::filesystem::path& path,
+			std::vector<std::string>& outItems,
+			std::string& outError)
+		{
+			outItems.clear();
+			outError.clear();
+
+			std::error_code ec;
+			if (!std::filesystem::exists(path, ec))
+				return true;
+
+			std::ifstream ifs(path);
+			if (!ifs.is_open())
+			{
+				outError = "Failed to open Preload.json.";
+				return false;
+			}
+
+			nlohmann::json j;
+			try
+			{
+				ifs >> j;
+			}
+			catch (...)
+			{
+				outError = "Preload.json parse failed.";
+				return false;
+			}
+
+			auto AppendFromArray = [&](const nlohmann::json& arr)
+			{
+				for (const auto& v : arr)
+				{
+					if (!v.is_string())
+						continue;
+					std::string s = TrimAscii(v.get<std::string>());
+					if (s.empty())
+						continue;
+					outItems.push_back(NormalizeLogicalPath(s));
+				}
+			};
+
+			if (j.is_array())
+			{
+				AppendFromArray(j);
+				return true;
+			}
+
+			if (j.contains("preload") && j["preload"].is_array())
+			{
+				AppendFromArray(j["preload"]);
+				return true;
+			}
+
+			if (j.contains("startup") && j["startup"].is_array())
+			{
+				AppendFromArray(j["startup"]);
+				return true;
+			}
+
+			// 인식 가능한 구조가 아니면 빈 목록으로 처리
+			return true;
+		}
+
+		bool SavePreloadJsonFile(const std::filesystem::path& path,
+			const std::vector<std::string>& items,
+			std::string& outError)
+		{
+			outError.clear();
+			std::error_code ec;
+			std::filesystem::create_directories(path.parent_path(), ec);
+
+			nlohmann::json j;
+			if (std::filesystem::exists(path, ec))
+			{
+				std::ifstream ifs(path);
+				if (ifs.is_open())
+				{
+					try { ifs >> j; }
+					catch (...) {}
+				}
+			}
+			if (!j.is_object())
+				j = nlohmann::json::object();
+			j["preload"] = items;
+
+			std::filesystem::path tmp = path;
+			tmp += ".tmp";
+			{
+				std::ofstream ofs(tmp);
+				if (!ofs.is_open())
+				{
+					outError = "Failed to write Preload.json (open failed).";
+					return false;
+				}
+				ofs << j.dump(4);
+			}
+
+			ec.clear();
+			std::filesystem::rename(tmp, path, ec);
+			if (ec)
+			{
+				std::filesystem::remove(path, ec);
+				ec.clear();
+				std::filesystem::rename(tmp, path, ec);
+			}
+			if (ec)
+			{
+				outError = "Failed to save Preload.json.";
+				return false;
+			}
+
+			return true;
+		}
+
+		bool ResolveLogicalExists(const std::string& logicalPath)
+		{
+			if (logicalPath.empty())
+				return false;
+			const std::filesystem::path resolved = ResourceManager::Get().Resolve(logicalPath);
+			std::error_code ec;
+			return std::filesystem::exists(resolved, ec);
+		}
+
+		bool AddPreloadItem(std::vector<std::string>& items,
+			const std::string& logicalPath,
+			std::string& outError)
+		{
+			outError.clear();
+			std::string normalized = NormalizeLogicalPath(TrimAscii(logicalPath));
+			if (normalized.empty())
+			{
+				outError = "Empty path.";
+				return false;
+			}
+			if (HasParentTraversal(normalized))
+			{
+				outError = "Invalid path (.. not allowed).";
+				return false;
+			}
+			if (!IsAllowedLogicalPath(normalized))
+			{
+				outError = "Only Assets/Resource/Cooked paths are allowed.";
+				return false;
+			}
+
+			const std::string key = ToLowerAscii(normalized);
+			for (const auto& item : items)
+			{
+				if (ToLowerAscii(item) == key)
+				{
+					outError = "Already exists in list.";
+					return false;
+				}
+			}
+
+			items.push_back(normalized);
+			return true;
+		}
+
+		std::vector<std::filesystem::path> ParseOpenFileBuffer(const wchar_t* buffer)
+		{
+			std::vector<std::filesystem::path> out;
+			if (!buffer || !buffer[0])
+				return out;
+
+			std::wstring first = buffer;
+			const wchar_t* p = buffer + first.size() + 1;
+			if (*p == L'\0')
+			{
+				out.emplace_back(first);
+				return out;
+			}
+
+			std::filesystem::path dir(first);
+			while (*p)
+			{
+				std::wstring name = p;
+				out.emplace_back(dir / name);
+				p += name.size() + 1;
+			}
+			return out;
+		}
+	}
+
+	void EditorCore::DrawPreloadAssetEditorWindow()
+	{
+		if (!g_PreloadEditorOpen)
+			return;
+
+		static std::filesystem::path s_loadedPath;
+		static std::filesystem::file_time_type s_loadedTime{};
+		static std::string s_statusMsg;
+		static bool s_statusError = false;
+
+		if (g_PreloadEditorPath != s_loadedPath)
+		{
+			std::string err;
+			if (!LoadPreloadJsonFile(g_PreloadEditorPath, g_PreloadEditorItems, err))
+			{
+				s_statusMsg = err;
+				s_statusError = true;
+			}
+			else
+			{
+				s_statusMsg.clear();
+				s_statusError = false;
+			}
+
+			g_PreloadEditorSelected = -1;
+			s_loadedPath = g_PreloadEditorPath;
+
+			std::error_code ec;
+			if (std::filesystem::exists(g_PreloadEditorPath, ec))
+				s_loadedTime = std::filesystem::last_write_time(g_PreloadEditorPath, ec);
+			else
+				s_loadedTime = {};
+		}
+
+		if (ImGui::Begin("Preload Asset Editor", &g_PreloadEditorOpen))
+		{
+			if (g_PreloadEditorPath.empty())
+			{
+				ImGui::TextDisabled("No Preload.json selected.");
+				ImGui::End();
+				return;
+			}
+
+			ImGui::Text("Asset: %s", g_PreloadEditorPath.string().c_str());
+
+			// 외부 변경 감지
+			{
+				std::error_code ec;
+				if (std::filesystem::exists(g_PreloadEditorPath, ec))
+				{
+					const auto currentTime = std::filesystem::last_write_time(g_PreloadEditorPath, ec);
+					if (!ec && currentTime != s_loadedTime)
+					{
+						ImGui::TextColored(ImVec4(1.0f, 0.8f, 0.2f, 1.0f), "File changed on disk.");
+						ImGui::SameLine();
+						if (ImGui::Button("Reload"))
+						{
+							std::string err;
+							if (!LoadPreloadJsonFile(g_PreloadEditorPath, g_PreloadEditorItems, err))
+							{
+								s_statusMsg = err;
+								s_statusError = true;
+							}
+							else
+							{
+								s_statusMsg.clear();
+								s_statusError = false;
+								s_loadedTime = currentTime;
+								g_PreloadEditorSelected = -1;
+							}
+						}
+					}
+				}
+			}
+
+			if (!s_statusMsg.empty())
+			{
+				const ImVec4 col = s_statusError ? ImVec4(1.0f, 0.4f, 0.4f, 1.0f) : ImVec4(0.6f, 1.0f, 0.6f, 1.0f);
+				ImGui::TextColored(col, "%s", s_statusMsg.c_str());
+			}
+
+			ImGui::Separator();
+
+			bool changed = false;
+
+			if (ImGui::Button("Add..."))
+			{
+				wchar_t fileBuffer[65536] = {};
+				OPENFILENAMEW ofn{};
+				ofn.lStructSize = sizeof(ofn);
+				ofn.hwndOwner = m_hwnd;
+				ofn.lpstrFilter = L"All Files\0*.*\0";
+				ofn.lpstrFile = fileBuffer;
+				ofn.nMaxFile = static_cast<DWORD>(sizeof(fileBuffer) / sizeof(fileBuffer[0]));
+				ofn.Flags = OFN_EXPLORER | OFN_FILEMUSTEXIST | OFN_PATHMUSTEXIST |
+					OFN_ALLOWMULTISELECT | OFN_NOCHANGEDIR;
+
+				const std::filesystem::path assetsDir = GetProjectRoot() / "Assets";
+				const std::wstring initDir = assetsDir.wstring();
+				ofn.lpstrInitialDir = initDir.c_str();
+
+				if (GetOpenFileNameW(&ofn))
+				{
+					const auto paths = ParseOpenFileBuffer(fileBuffer);
+					for (const auto& p : paths)
+					{
+						std::string logical;
+						std::string err;
+						if (!TryMakeLogicalPath(p, logical))
+						{
+							s_statusMsg = "Selected file is outside Assets/Resource/Cooked.";
+							s_statusError = true;
+							continue;
+						}
+						if (AddPreloadItem(g_PreloadEditorItems, logical, err))
+						{
+							changed = true;
+						}
+						else if (!err.empty())
+						{
+							s_statusMsg = err;
+							s_statusError = true;
+						}
+					}
+				}
+			}
+
+			ImGui::SameLine();
+			if (ImGui::Button("Remove Selected") &&
+				g_PreloadEditorSelected >= 0 &&
+				g_PreloadEditorSelected < static_cast<int>(g_PreloadEditorItems.size()))
+			{
+				g_PreloadEditorItems.erase(g_PreloadEditorItems.begin() + g_PreloadEditorSelected);
+				g_PreloadEditorSelected = -1;
+				changed = true;
+			}
+
+			ImGui::SameLine();
+			if (ImGui::Button("Clear All"))
+			{
+				g_PreloadEditorItems.clear();
+				g_PreloadEditorSelected = -1;
+				changed = true;
+			}
+
+			ImGui::Spacing();
+			ImGui::TextDisabled("Drag assets here to add (Assets/Resource/Cooked only).");
+			ImGui::BeginChild("PreloadDropArea", ImVec2(0, 60.0f), true);
+			ImGui::TextUnformatted("Drop files from Project panel.");
+			if (ImGui::BeginDragDropTarget())
+			{
+				if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("ASSET_FILE_PATH"))
+				{
+					const char* pathStr = static_cast<const char*>(payload->Data);
+					std::filesystem::path droppedPath(pathStr);
+
+					std::string logical;
+					std::string err;
+					if (TryMakeLogicalPath(droppedPath, logical))
+					{
+						if (AddPreloadItem(g_PreloadEditorItems, logical, err))
+							changed = true;
+						else if (!err.empty())
+						{
+							s_statusMsg = err;
+							s_statusError = true;
+						}
+					}
+					else
+					{
+						s_statusMsg = "Dropped file is outside Assets/Resource/Cooked.";
+						s_statusError = true;
+					}
+				}
+				ImGui::EndDragDropTarget();
+			}
+			ImGui::EndChild();
+
+			ImGui::Separator();
+
+			if (g_PreloadEditorItems.empty())
+			{
+				ImGui::TextDisabled("No preload entries.");
+			}
+			else if (ImGui::BeginTable("PreloadList", 4, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_SizingStretchProp))
+			{
+				ImGui::TableSetupColumn("Path");
+				ImGui::TableSetupColumn("Up", ImGuiTableColumnFlags_WidthFixed, 40.0f);
+				ImGui::TableSetupColumn("Down", ImGuiTableColumnFlags_WidthFixed, 50.0f);
+				ImGui::TableSetupColumn("Del", ImGuiTableColumnFlags_WidthFixed, 40.0f);
+				ImGui::TableHeadersRow();
+
+				for (int i = 0; i < static_cast<int>(g_PreloadEditorItems.size()); ++i)
+				{
+					const std::string& path = g_PreloadEditorItems[i];
+					const std::string normalized = NormalizeLogicalPath(path);
+					const bool allowed = IsAllowedLogicalPath(normalized) && !HasParentTraversal(normalized);
+					const bool exists = allowed && ResolveLogicalExists(normalized);
+
+					ImGui::TableNextRow();
+					ImGui::TableSetColumnIndex(0);
+
+					ImGui::PushID(i);
+					if (!allowed)
+						ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(255, 90, 90, 255));
+					else if (!exists)
+						ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(255, 200, 90, 255));
+
+					const std::string label = normalized + "##preload";
+					if (ImGui::Selectable(label.c_str(), g_PreloadEditorSelected == i))
+						g_PreloadEditorSelected = i;
+
+					if (!allowed)
+					{
+						ImGui::PopStyleColor();
+						if (ImGui::IsItemHovered())
+							ImGui::SetTooltip("Invalid path (must be Assets/Resource/Cooked)");
+					}
+					else if (!exists)
+					{
+						ImGui::PopStyleColor();
+						if (ImGui::IsItemHovered())
+							ImGui::SetTooltip("Missing file on disk.");
+					}
+
+					ImGui::TableSetColumnIndex(1);
+					const bool canUp = (i > 0);
+					ImGui::BeginDisabled(!canUp);
+					if (ImGui::ArrowButton("##Up", ImGuiDir_Up) && canUp)
+					{
+						std::swap(g_PreloadEditorItems[i], g_PreloadEditorItems[i - 1]);
+						g_PreloadEditorSelected = i - 1;
+						changed = true;
+					}
+					ImGui::EndDisabled();
+
+					ImGui::TableSetColumnIndex(2);
+					const bool canDown = (i + 1 < static_cast<int>(g_PreloadEditorItems.size()));
+					ImGui::BeginDisabled(!canDown);
+					if (ImGui::ArrowButton("##Down", ImGuiDir_Down) && canDown)
+					{
+						std::swap(g_PreloadEditorItems[i], g_PreloadEditorItems[i + 1]);
+						g_PreloadEditorSelected = i + 1;
+						changed = true;
+					}
+					ImGui::EndDisabled();
+
+					ImGui::TableSetColumnIndex(3);
+					if (ImGui::SmallButton("X"))
+					{
+						g_PreloadEditorItems.erase(g_PreloadEditorItems.begin() + i);
+						if (g_PreloadEditorSelected == i)
+							g_PreloadEditorSelected = -1;
+						else if (g_PreloadEditorSelected > i)
+							--g_PreloadEditorSelected;
+						changed = true;
+					}
+
+					ImGui::PopID();
+				}
+
+				ImGui::EndTable();
+			}
+
+			ImGui::Spacing();
+			ImGui::TextDisabled("Tip: Put Preload.json under Assets/Startup for build-time chunking.");
+
+			if (changed)
+			{
+				std::string err;
+				if (!SavePreloadJsonFile(g_PreloadEditorPath, g_PreloadEditorItems, err))
+				{
+					s_statusMsg = err;
+					s_statusError = true;
+				}
+				else
+				{
+					s_statusMsg = "Saved.";
+					s_statusError = false;
+					std::error_code ec;
+					if (std::filesystem::exists(g_PreloadEditorPath, ec))
+						s_loadedTime = std::filesystem::last_write_time(g_PreloadEditorPath, ec);
+				}
+			}
+		}
+		ImGui::End();
+	}
+}

--- a/Engine/src/Editor/Core/EditorCore.cpp
+++ b/Engine/src/Editor/Core/EditorCore.cpp
@@ -111,6 +111,10 @@ namespace Alice
 	std::filesystem::path g_UICurveEditorPath{};
 	UICurveAsset g_UICurveEditorData{};
 	int g_UICurveEditorSelected = -1;
+	bool g_PreloadEditorOpen = false;
+	std::filesystem::path g_PreloadEditorPath{};
+	std::vector<std::string> g_PreloadEditorItems{};
+	int g_PreloadEditorSelected = -1;
 
 	// ICommand는 이제 EditorCore.h에 정의됨
 
@@ -395,6 +399,7 @@ namespace Alice
 
 		DrawMaterialAssetEditorWindow(world);
 		DrawUICurveAssetEditorWindow();
+		DrawPreloadAssetEditorWindow();
 
 		DrawEngineLogo();
 

--- a/Engine/src/Editor/Core/EditorCore.h
+++ b/Engine/src/Editor/Core/EditorCore.h
@@ -405,6 +405,7 @@ namespace Alice
 		bool SaveLightingSettingsForBuild(const std::filesystem::path& projectRoot) const;
 		void DrawMaterialAssetEditorWindow(World& world);
 		void DrawUICurveAssetEditorWindow();
+		void DrawPreloadAssetEditorWindow();
 		void HandleSceneLoadFlow(World& world, SceneManager* sceneManager, bool& isPlaying, EntityId& selectedEntity);
 
 		// UI

--- a/Engine/src/Editor/Core/EditorUIState.h
+++ b/Engine/src/Editor/Core/EditorUIState.h
@@ -2,6 +2,7 @@
 
 #include <filesystem>
 #include <string>
+#include <vector>
 
 #include "Runtime/Rendering/Components/MaterialComponent.h"
 #include "Runtime/UI/UICurveAsset.h"
@@ -35,4 +36,10 @@ namespace Alice
 	extern std::filesystem::path g_UICurveEditorPath;
 	extern UICurveAsset g_UICurveEditorData;
 	extern int g_UICurveEditorSelected;
+
+	// Preload asset editor state
+	extern bool g_PreloadEditorOpen;
+	extern std::filesystem::path g_PreloadEditorPath;
+	extern std::vector<std::string> g_PreloadEditorItems;
+	extern int g_PreloadEditorSelected;
 }

--- a/Engine/src/Editor/Inspector/Inspector_Rendering.cpp
+++ b/Engine/src/Editor/Inspector/Inspector_Rendering.cpp
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <commdlg.h>
 #include <fstream>
+#include <string>
 
 namespace Alice
 {
@@ -23,6 +24,24 @@ namespace Alice
 			return propName != "assetPath" && propName != "albedoTexturePath" && propName != "shadingMode" &&
 			       propName != "shadowStrength" && propName != "toonPbrRampIntensity" &&
 			       propName != "toonSelfShadowStrength";
+		}
+
+		inline bool DragFloatWithInput(const char* label, float* value, float minValue, float maxValue, const char* fmt = "%.3f")
+		{
+			float speed = (maxValue - minValue) / 200.0f;
+			if (speed <= 0.0f) speed = 0.01f;
+
+			float v = *value;
+			bool changed = ImGui::DragFloat(label, &v, speed, minValue, maxValue, fmt);
+			ImGui::SameLine();
+			ImGui::SetNextItemWidth(90.0f);
+			std::string inputId = std::string("##") + label + "_input";
+			changed |= ImGui::InputFloat(inputId.c_str(), &v, 0.0f, 0.0f, fmt);
+
+			if (changed)
+				*value = std::clamp(v, minValue, maxValue);
+
+			return changed;
 		}
 	}
 
@@ -305,8 +324,8 @@ namespace Alice
 				bool changed = false;
 				changed |= ImGui::Checkbox("Enabled##PointLight", &light->enabled);
 				changed |= ImGui::ColorEdit3("Color##PointLight", &light->color.x);
-				changed |= ImGui::SliderFloat("Intensity##PointLight", &light->intensity, 0.0f, 50.0f);
-				changed |= ImGui::SliderFloat("Range##PointLight", &light->range, 0.1f, 200.0f);
+				changed |= DragFloatWithInput("Intensity##PointLight", &light->intensity, 0.0f, 50.0f);
+				changed |= DragFloatWithInput("Range##PointLight", &light->range, 0.1f, 200.0f);
 
 				if (ImGui::Button("Remove Point Light")) {
 					world.RemoveComponent<PointLightComponent>(_selectedEntity);
@@ -327,8 +346,8 @@ namespace Alice
 				bool changed = false;
 				changed |= ImGui::Checkbox("Enabled##SpotLight", &light->enabled);
 				changed |= ImGui::ColorEdit3("Color##SpotLight", &light->color.x);
-				changed |= ImGui::SliderFloat("Intensity##SpotLight", &light->intensity, 0.0f, 50.0f);
-				changed |= ImGui::SliderFloat("Range##SpotLight", &light->range, 0.1f, 200.0f);
+				changed |= DragFloatWithInput("Intensity##SpotLight", &light->intensity, 0.0f, 50.0f);
+				changed |= DragFloatWithInput("Range##SpotLight", &light->range, 0.1f, 200.0f);
 				changed |= ImGui::SliderFloat("Inner Angle (deg)##SpotLight", &light->innerAngleDeg, 0.0f, 89.0f);
 				changed |= ImGui::SliderFloat("Outer Angle (deg)##SpotLight", &light->outerAngleDeg, 0.0f, 89.0f);
 
@@ -354,10 +373,10 @@ namespace Alice
 				bool changed = false;
 				changed |= ImGui::Checkbox("Enabled##RectLight", &light->enabled);
 				changed |= ImGui::ColorEdit3("Color##RectLight", &light->color.x);
-				changed |= ImGui::SliderFloat("Intensity##RectLight", &light->intensity, 0.0f, 50.0f);
+				changed |= DragFloatWithInput("Intensity##RectLight", &light->intensity, 0.0f, 50.0f);
 				changed |= ImGui::SliderFloat("Width##RectLight", &light->width, 0.1f, 50.0f);
 				changed |= ImGui::SliderFloat("Height##RectLight", &light->height, 0.1f, 50.0f);
-				changed |= ImGui::SliderFloat("Range##RectLight", &light->range, 0.1f, 200.0f);
+				changed |= DragFloatWithInput("Range##RectLight", &light->range, 0.1f, 200.0f);
 
 				if (ImGui::Button("Remove Rect Light")) {
 					world.RemoveComponent<RectLightComponent>(_selectedEntity);

--- a/Engine/src/Editor/Inspector/Inspector_Rendering.cpp
+++ b/Engine/src/Editor/Inspector/Inspector_Rendering.cpp
@@ -29,7 +29,8 @@ namespace Alice
 	void EditorCore::DrawInspectorMaterial(World& world, const EntityId& _selectedEntity)
 	{
 		if (auto* mat = world.GetComponent<MaterialComponent>(_selectedEntity)) {
-			ImGui::Text("Material");
+			if (!ImGui::CollapsingHeader("Material", ImGuiTreeNodeFlags_DefaultOpen))
+				return;
 			if (!mat->assetPath.empty())
 				ImGui::Text("Asset: %s", mat->assetPath.c_str());
 

--- a/Engine/src/Editor/Inspector/Inspector_Transform.cpp
+++ b/Engine/src/Editor/Inspector/Inspector_Transform.cpp
@@ -2,6 +2,7 @@
 #include "Editor/Core/EditorCommands.h"
 #include "Editor/Core/EditorUIState.h"
 #include "Runtime/ECS/Components/TransformComponent.h"
+#include "Runtime/Gameplay/Animation/AdvancedAnimationComponent.h"
 #include "Runtime/Importing/FbxModel.h"
 #include "Runtime/Rendering/Components/PostProcessVolumeComponent.h"
 #include <DirectXMath.h>
@@ -175,6 +176,15 @@ namespace Alice
 		{
 			if (ImGui::CollapsingHeader("Animation Status", ImGuiTreeNodeFlags_DefaultOpen))
 			{
+				const bool hasAdvanced = (world.GetComponent<AdvancedAnimationComponent>(_selectedEntity) != nullptr);
+				if (hasAdvanced)
+				{
+					ImGui::TextColored(ImVec4(0.2f, 0.6f, 1.0f, 1.0f), "AdvancedAnimation");
+				}
+				else
+				{
+					ImGui::TextColored(ImVec4(0.2f, 1.0f, 0.2f, 1.0f), "SkinnedAnimation");
+				}
 				ImGui::Text("Playing: %s", anim->playing ? "Yes" : "No");
 				ImGui::Text("Speed: %.2f", anim->speed);
 				ImGui::Text("Clip Index: %d", anim->clipIndex);

--- a/Engine/src/Editor/Panels/CameraPanel.cpp
+++ b/Engine/src/Editor/Panels/CameraPanel.cpp
@@ -13,6 +13,7 @@
 #include "imgui.h"
 
 #include <algorithm>
+#include <cmath>
 #include <DirectXMath.h>
 
 using namespace DirectX;
@@ -202,7 +203,19 @@ namespace Alice
 									}
 									anim->clipIndex = clip;
 
+									const std::string& clipName = names[(size_t)clip];
+									ImGui::Text("Clip Name: %s", clipName.c_str());
+									ImGui::SameLine();
+									if (ImGui::SmallButton("Copy##ClipName"))
+									{
+										ImGui::SetClipboardText(clipName.c_str());
+									}
+									if (ImGui::IsItemHovered())
+										ImGui::SetTooltip("Copy clip name");
+
 									const double dur = mesh->sourceModel->GetClipDurationSec(anim->clipIndex);
+									if (dur > 0.0 && anim->timeSec >= dur)
+										anim->timeSec = std::fmod(anim->timeSec, dur);
 									float timeSec = (float)anim->timeSec;
 									float durF = (dur > 0.0) ? (float)dur : 0.0f;
 

--- a/Engine/src/Editor/Panels/InspectorPanel.cpp
+++ b/Engine/src/Editor/Panels/InspectorPanel.cpp
@@ -6,11 +6,15 @@
 #include "Runtime/Resources/ResourceManager.h"
 #include "Runtime/Resources/Prefab.h"
 #include "Runtime/Rendering/Components/SkinnedMeshComponent.h"
+#include "Runtime/Rendering/Data/Material.h"
+#include "Runtime/Importing/FbxImporter.h"
+#include "Runtime/Importing/FbxAsset.h"
 #include "Runtime/Importing/FbxModel.h"
 
 #include "imgui.h"
 
 #include <algorithm>
+#include <commdlg.h>
 #include <filesystem>
 
 namespace Alice
@@ -147,50 +151,185 @@ namespace Alice
 			if (auto* skinned =
 				world.GetComponent<SkinnedMeshComponent>(selectedEntity)) {
 				ImGui::Separator();
-				ImGui::Text("Skinned Mesh: %s", skinned->meshAssetPath.c_str());
-
-				// 본 목록 미니 뷰 (이름 확인용)
-				if (m_skinnedRegistry) {
-					auto mesh = m_skinnedRegistry->Find(skinned->meshAssetPath);
-					if (mesh && mesh->sourceModel) {
-						const auto& bones = mesh->sourceModel->GetBoneNames();
-						if (ImGui::TreeNode("Bones")) {
-							for (size_t i = 0; i < bones.size(); ++i) {
-								ImGui::Text("%zu: %s", i, bones[i].c_str());
-							}
-							ImGui::TreePop();
-						}
-					}
-				}
-
-				// 메시 경로 필드에 드롭 타겟 추가
-				if (ImGui::BeginDragDropTarget())
+				if (ImGui::CollapsingHeader("Skinned Mesh", ImGuiTreeNodeFlags_DefaultOpen))
 				{
-					if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("ASSET_FILE_PATH"))
-					{
-						const char* pathStr = static_cast<const char*>(payload->Data);
-						std::filesystem::path droppedPath(pathStr);
-						std::string ext = droppedPath.extension().string();
+					ImGui::Text("Skinned Mesh: %s", skinned->meshAssetPath.c_str());
+					ImGui::Text("Instance Asset: %s", skinned->instanceAssetPath.empty() ? "None" : skinned->instanceAssetPath.c_str());
 
-						// FBX 파일인지 확인
+					ImGui::PushID("SkinnedMeshBrowse");
+					if (ImGui::Button("Browse..."))
+					{
+					// 프로젝트 루트 기준 경로 계산
+					wchar_t exePathW[MAX_PATH] = {};
+					GetModuleFileNameW(nullptr, exePathW, MAX_PATH);
+					std::filesystem::path exeDir = std::filesystem::path(exePathW).parent_path();
+					std::filesystem::path projectRoot = exeDir.parent_path().parent_path().parent_path();
+					std::filesystem::path resourceDir = projectRoot / "Resource";
+					if (!std::filesystem::exists(resourceDir))
+						resourceDir = projectRoot;
+
+					std::wstring initialDirW = resourceDir.wstring();
+
+					wchar_t fileBuffer[MAX_PATH] = {};
+					OPENFILENAMEW ofn{};
+					ofn.lStructSize = sizeof(ofn);
+					ofn.hwndOwner = m_hwnd;
+					ofn.lpstrFilter = L"FBX/FBXAsset\0*.fbx;*.fbxasset\0FBX\0*.fbx\0FBX Asset\0*.fbxasset\0All Files\0*.*\0";
+					ofn.lpstrFile = fileBuffer;
+					ofn.nMaxFile = MAX_PATH;
+					ofn.lpstrInitialDir = initialDirW.c_str();
+					ofn.Flags = OFN_EXPLORER | OFN_FILEMUSTEXIST | OFN_PATHMUSTEXIST | OFN_NOCHANGEDIR;
+
+					if (GetOpenFileNameW(&ofn))
+					{
+						std::filesystem::path pickedPath = fileBuffer;
+						std::string ext = pickedPath.extension().string();
 						std::transform(ext.begin(), ext.end(), ext.begin(),
 							[](unsigned char c) { return static_cast<char>(std::tolower(c)); });
-						if (ext == ".fbx" || ext == ".fbxasset")
+
+						// .fbxasset 선택: 인스턴스 경로로 연결
+						if (ext == ".fbxasset")
 						{
-							// 논리 경로로 변환
-							std::string logicalPath = droppedPath.string();
+							std::string logicalPath = pickedPath.string();
 							{
-								std::filesystem::path logical = ResourceManager::NormalizeResourcePathAbsoluteToLogical(droppedPath);
-								if (!logical.empty())
+								std::filesystem::path logical = ResourceManager::NormalizeResourcePathAbsoluteToLogical(pickedPath);
+								if (!logical.empty() && !logical.is_absolute())
+									logicalPath = logical.generic_string();
+								else
 								{
-									logicalPath = logical.string();
+									std::error_code ec;
+									std::filesystem::path rel = std::filesystem::relative(pickedPath, projectRoot, ec);
+									if (!ec && !rel.empty())
+										logicalPath = rel.generic_string();
 								}
 							}
-							skinned->meshAssetPath = logicalPath;
-							g_SceneDirty = true;
+
+							FbxInstanceAsset asset{};
+							if (LoadFbxInstanceAssetAuto(ResourceManager::Get(), logicalPath, asset))
+							{
+								skinned->instanceAssetPath = logicalPath;
+								skinned->meshAssetPath = asset.meshAssetPath;
+
+								static DirectX::XMFLOAT4X4 s_identityBone =
+									DirectX::XMFLOAT4X4(1, 0, 0, 0,
+										0, 1, 0, 0,
+										0, 0, 1, 0,
+										0, 0, 0, 1);
+								skinned->boneMatrices = &s_identityBone;
+								skinned->boneCount = 1;
+
+								if (m_renderDevice && m_skinnedRegistry && !asset.sourceFbx.empty())
+								{
+									FbxImporter importer(ResourceManager::Get(), m_skinnedRegistry);
+									importer.Import(m_renderDevice->GetDevice(),
+										ResourceManager::Get().Resolve(asset.sourceFbx), {});
+								}
+								g_SceneDirty = true;
+							}
+						}
+						// .fbx 선택: 임포트 후 컴포넌트에 연결
+						else if (ext == ".fbx")
+						{
+							if (m_renderDevice)
+							{
+								std::filesystem::path fbxPath = pickedPath;
+								std::error_code ec;
+								std::filesystem::path rel = std::filesystem::relative(pickedPath, projectRoot, ec);
+								if (!ec && !rel.empty())
+									fbxPath = rel;
+
+								FbxImportOptions opt{};
+								FbxImporter importer(ResourceManager::Get(), m_skinnedRegistry);
+								FbxImportResult result = importer.Import(m_renderDevice->GetDevice(), fbxPath, opt);
+
+								if (!result.meshAssetPath.empty())
+								{
+									skinned->meshAssetPath = result.meshAssetPath;
+									skinned->instanceAssetPath = result.instanceAssetPath;
+
+									static DirectX::XMFLOAT4X4 s_identityBone =
+										DirectX::XMFLOAT4X4(1, 0, 0, 0,
+											0, 1, 0, 0,
+											0, 0, 1, 0,
+											0, 0, 0, 1);
+									skinned->boneMatrices = &s_identityBone;
+									skinned->boneCount = 1;
+
+									if (!result.materialAssetPaths.empty())
+									{
+										MaterialComponent* mat = world.GetComponent<MaterialComponent>(selectedEntity);
+										if (!mat)
+										{
+											DirectX::XMFLOAT3 defaultColor(0.7f, 0.7f, 0.7f);
+											mat = &world.AddComponent<MaterialComponent>(selectedEntity, defaultColor);
+										}
+										mat->assetPath = result.materialAssetPaths.front();
+										MaterialFile::Load(mat->assetPath, *mat, &ResourceManager::Get());
+									}
+
+									g_SceneDirty = true;
+								}
+							}
 						}
 					}
-					ImGui::EndDragDropTarget();
+					}
+					ImGui::PopID();
+
+					ImGui::SameLine();
+					ImGui::PushID("SkinnedMeshClear");
+					if (ImGui::Button("Clear"))
+					{
+						skinned->meshAssetPath.clear();
+						skinned->instanceAssetPath.clear();
+						skinned->boneMatrices = nullptr;
+						skinned->boneCount = 0;
+						g_SceneDirty = true;
+					}
+					ImGui::PopID();
+
+					// 본 목록 미니 뷰 (이름 확인용)
+					if (m_skinnedRegistry) {
+						auto mesh = m_skinnedRegistry->Find(skinned->meshAssetPath);
+						if (mesh && mesh->sourceModel) {
+							const auto& bones = mesh->sourceModel->GetBoneNames();
+							if (ImGui::TreeNode("Bones")) {
+								for (size_t i = 0; i < bones.size(); ++i) {
+									ImGui::Text("%zu: %s", i, bones[i].c_str());
+								}
+								ImGui::TreePop();
+							}
+						}
+					}
+
+					// 메시 경로 필드에 드롭 타겟 추가
+					if (ImGui::BeginDragDropTarget())
+					{
+						if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("ASSET_FILE_PATH"))
+						{
+							const char* pathStr = static_cast<const char*>(payload->Data);
+							std::filesystem::path droppedPath(pathStr);
+							std::string ext = droppedPath.extension().string();
+
+							// FBX 파일인지 확인
+							std::transform(ext.begin(), ext.end(), ext.begin(),
+								[](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+							if (ext == ".fbx" || ext == ".fbxasset")
+							{
+								// 논리 경로로 변환
+								std::string logicalPath = droppedPath.string();
+								{
+									std::filesystem::path logical = ResourceManager::NormalizeResourcePathAbsoluteToLogical(droppedPath);
+									if (!logical.empty())
+									{
+										logicalPath = logical.string();
+									}
+								}
+								skinned->meshAssetPath = logicalPath;
+								g_SceneDirty = true;
+							}
+						}
+						ImGui::EndDragDropTarget();
+					}
 				}
 			}
 		}

--- a/Engine/src/Editor/Project/DirectoryTree.cpp
+++ b/Engine/src/Editor/Project/DirectoryTree.cpp
@@ -17,6 +17,29 @@
 
 namespace Alice
 {
+	namespace
+	{
+		bool WritePreloadJsonSample(const std::filesystem::path& path)
+		{
+			namespace fs = std::filesystem;
+			std::error_code ec;
+			fs::create_directories(path.parent_path(), ec);
+
+			nlohmann::json j;
+			j["preload"] = nlohmann::json::array({
+				"Resource/Icon/AliceBanner.png",
+				"Resource/Fonts/NotoSansKR-Regular.ttf",
+				"Resource/Fonts/meiryo.ttc"
+				});
+
+			std::ofstream ofs(path);
+			if (!ofs.is_open())
+				return false;
+			ofs << j.dump(4);
+			return true;
+		}
+	}
+
 	void EditorCore::DrawDirectoryNode(World& world,
 		EntityId& selectedEntity,
 		const std::filesystem::path& path)
@@ -170,6 +193,21 @@ namespace Alice
 					{
 						ALICE_LOG_ERRORF("[EditorCore] Failed to create Curve asset: %s", curvePath.string().c_str());
 					}
+				}
+
+				// Preload.json 생성
+				if (ImGui::MenuItem("Create Preload.json"))
+				{
+					fs::path preloadPath = path / "Preload.json";
+					if (!fs::exists(preloadPath))
+					{
+						if (!WritePreloadJsonSample(preloadPath))
+						{
+							ALICE_LOG_ERRORF("[EditorCore] Failed to create Preload.json: %s", preloadPath.string().c_str());
+						}
+					}
+					g_PreloadEditorPath = preloadPath;
+					g_PreloadEditorOpen = true;
 				}
 
 				// Unity 스타일: C++ 스크립트(.h/.cpp)와 프리팹을 간단하게 생성합니다.
@@ -436,6 +474,11 @@ namespace Alice
 					g_UICurveEditorData.RecalcAutoTangents();
 					g_UICurveEditorSelected = -1;
 					g_UICurveEditorOpen = true;
+				}
+				else if (_stricmp(path.filename().string().c_str(), "Preload.json") == 0)
+				{
+					g_PreloadEditorPath = path;
+					g_PreloadEditorOpen = true;
 				}
 			}
 

--- a/Engine/src/Editor/Scripting/ScriptReloadHelpers.cpp
+++ b/Engine/src/Editor/Scripting/ScriptReloadHelpers.cpp
@@ -33,6 +33,14 @@ namespace Alice
 			// 전체 명령어를 " "로 감싸서 공백이나 특수문자 문제를 방지합니다.
 			std::wstring finalCmd = L"cmd.exe /C \"" + command + L"\"";
 
+
+			// 만약 알 수 없이 실패한다면 위의 finalCmd 쪽을 주석시키고 밑의 주석을 풀어보세요.
+			// 전체 명령어를 " "로 감싸서 공백이나 특수문자 문제를 방지합니다.
+			// 실패 시 콘솔이 바로 꺼지지 않도록 pause를 걸고, 원래 에러코드를 반환합니다.
+			//std::wstring finalCmd = L"cmd.exe /C \"";
+			//finalCmd += command;
+			//finalCmd += L" & set _exit=%errorlevel% & if not %_exit%==0 (echo. & echo Press any key to close... & pause >nul) & exit /b %_exit%\"";
+
 			// CreateProcess는 문자열 버퍼를 수정할 수 있어야 하므로 vector에 복사
 			std::vector<wchar_t> cmdBuffer(finalCmd.begin(), finalCmd.end());
 			cmdBuffer.push_back(0); // Null terminator

--- a/Engine/src/Editor/Tools/BuildGameWindow.cpp
+++ b/Engine/src/Editor/Tools/BuildGameWindow.cpp
@@ -142,6 +142,29 @@ namespace Alice
 			return true;
 		}
 
+		// 빌드 파일 뽑아내고 Release에 남아있는 파일들 삭제하기
+		void RemovePathIfExists(const std::filesystem::path& path)
+		{
+			namespace fs = std::filesystem;
+			std::error_code ec;
+			if (!fs::exists(path, ec) || ec)
+				return;
+			ec.clear();
+			if (fs::is_directory(path, ec))
+			{
+				fs::remove_all(path, ec);
+			}
+			else
+			{
+				fs::remove(path, ec);
+			}
+			if (ec)
+			{
+				ALICE_LOG_ERRORF("Build Game: cleanup failed. \"%s\" (%s)",
+					path.string().c_str(), ec.message().c_str());
+			}
+		}
+
 		// srcRoot의 모든 파일을 dstCookedRoot/<rel>.alice 로 "암호화 저장"합니다(폴더 구조 유지, 확장자는 .alice로 통일).
 		// - 이미 암호화된 .alice 는 그대로 복사합니다(중복 암호화 방지).
 		// - excludePrefixRel(예: "Resource/")로 시작하는 rel 경로는 스킵할 수 있습니다.
@@ -563,6 +586,14 @@ namespace Alice
 					g_BuildInProgress.store(false);
 					return;
 				}
+
+				// (6) Cleanup: Release 스테이징 파일 정리 (복사 완료 후)
+				RemovePathIfExists(releaseBinDir / "AlicePlayer.exe");
+				RemovePathIfExists(releaseBinDir / "dll");
+				RemovePathIfExists(releaseBinDir / "Cooked");
+				RemovePathIfExists(releaseBinDir / "Metas");
+				RemovePathIfExists(releaseBinDir / "BuildSettings.json");
+				RemovePathIfExists(releaseBinDir / "EngineSettings.json");
 
 				ALICE_LOG_INFO("Build Game: exported to \"%s\" (run: Bin/AlicePlayer.exe)",
 					exportRoot.string().c_str());

--- a/Engine/src/Editor/UI/EditorMainMenuBar.cpp
+++ b/Engine/src/Editor/UI/EditorMainMenuBar.cpp
@@ -17,6 +17,7 @@
 #include "Runtime/ECS/Components/TransformComponent.h"
 #include "Runtime/Rendering/Components/MaterialComponent.h"
 #include "Runtime/Rendering/Components/SkinnedMeshComponent.h"
+#include "Runtime/Rendering/Components/PostProcessVolumeComponent.h"
 #include "ThirdParty/json/json.hpp"
 
 #include "imgui.h"
@@ -232,6 +233,19 @@ namespace Alice
 				{
 					EntityId e = world.CreateRectLight();
 					PushCommand(std::make_unique<CreateEntityCommand>(e, "Rect Light"));
+					selectedEntity = e;
+					g_SceneDirty = true;
+					ImGui::CloseCurrentPopup();
+				}
+				ImGui::EndMenu();
+			}
+			if (ImGui::BeginMenu("Post-processing"))
+			{
+				if (ImGui::MenuItem("Post Process Volume"))
+				{
+					EntityId e = world.CreateEmpty();
+					world.AddComponent<PostProcessVolumeComponent>(e);
+					PushCommand(std::make_unique<CreateEntityCommand>(e, "Post Process Volume"));
 					selectedEntity = e;
 					g_SceneDirty = true;
 					ImGui::CloseCurrentPopup();

--- a/Engine/src/Runtime/Engine/Engine.cpp
+++ b/Engine/src/Runtime/Engine/Engine.cpp
@@ -54,6 +54,9 @@ namespace Alice
 
 	int Engine::Run()
 	{
+		if (pImpl->m_initCanceled)
+			return 0;
+
 		// 타이머 초기화
 		pImpl->m_isRunning = true;
 		pImpl->m_timer.Reset();

--- a/Engine/src/Runtime/Engine/EngineImpl.h
+++ b/Engine/src/Runtime/Engine/EngineImpl.h
@@ -74,6 +74,7 @@
 #include "Runtime/Importing/FbxAsset.h"
 #include <dxgi1_3.h>
 #include <unordered_set>
+#include <unordered_map>
 
 #include "Runtime/Importing/FbxModel.h"
 
@@ -103,6 +104,7 @@ namespace Alice
 		bool m_isRunning = false;            // 엔진 자체가 실행중인지 판단
 		bool m_isPlaying = false;            // 재생 / 일시정지 상태 (에디터 모드에서만 사용)
 		bool m_editorMode = true;             // true: 에디터, false: 게임 전용
+		bool m_initCanceled = false;         // 초기화 중 사용자 종료 요청
 		bool m_debugDraw = true;
 		EntityId m_selectedEntity{ InvalidEntityId }; // 현재 선택된 엔티티 (하이러키)
 
@@ -187,6 +189,7 @@ namespace Alice
 		AttackDriverSystem m_attackDriverSystem;
 		AudioSystem m_audioSystem;
 		std::vector<SkinnedDrawCommand> m_skinnedDrawCommands;
+		std::unordered_map<std::string, std::shared_ptr<const std::vector<std::uint8_t>>> m_preloadedBlobs;
 
 		bool m_animUpdatedThisFrame = false;
 
@@ -211,6 +214,7 @@ namespace Alice
 		bool InitializeRenderSystems();
 		bool InitializeUI();
 		bool InitializeComputeEffectSystem();
+		bool InitializePreloadAndLoadingScreen(const std::filesystem::path& exeDir);
 		void InitializeCameraAndScriptHotReload();
 		bool InitializeScene(const std::filesystem::path& exeDir);
 		bool InitializePhysicsSystemAndWorldCallbacks();

--- a/Engine/src/Runtime/Engine/EngineInitialize.cpp
+++ b/Engine/src/Runtime/Engine/EngineInitialize.cpp
@@ -1,10 +1,21 @@
 #include "Runtime/Engine/EngineImpl.h"
 #include "Runtime/ECS/Components/TransformComponent.h"
 #include "Runtime/Resources/Prefab.h"
+#include "Runtime/UI/UIWidgetComponent.h"
+#include "Runtime/UI/UITransformComponent.h"
+#include "Runtime/UI/UIImageComponent.h"
+#include "Runtime/UI/UITextComponent.h"
+#include "Runtime/UI/UIGaugeComponent.h"
+#include "Runtime/UI/UIEffectComponent.h"
+#include "Runtime/Importing/FbxAnimation.h"
 #include <Windows.h>
 #include <algorithm>
 #include <chrono>
 #include <thread>
+#include <cctype>
+#include <cstdio>
+#include <unordered_set>
+#include <cmath>
 
 namespace Alice
 {
@@ -104,9 +115,354 @@ namespace Alice
 				return;
 			}
 
-			ofs << j.dump(4); // 들여쓰기 4칸으로 포맷
-			ALICE_LOG_INFO("PVD settings saved to EngineSettings.json");
+		ofs << j.dump(4); // 들여쓰기 4칸으로 포맷
+		ALICE_LOG_INFO("PVD settings saved to EngineSettings.json");
+	}
+
+	std::string TrimAsciiRuntime(const std::string& s)
+	{
+		size_t start = 0;
+		while (start < s.size() && std::isspace(static_cast<unsigned char>(s[start])))
+			++start;
+		size_t end = s.size();
+		while (end > start && std::isspace(static_cast<unsigned char>(s[end - 1])))
+			--end;
+		return s.substr(start, end - start);
+	}
+
+	std::string NormalizeLogicalPathRuntime(const std::string& s)
+	{
+		std::string temp = s;
+		std::replace(temp.begin(), temp.end(), '\\', '/');
+		if (temp.rfind("./", 0) == 0)
+			temp = temp.substr(2);
+		std::filesystem::path p(temp);
+		std::string normalized = p.lexically_normal().generic_string();
+		if (normalized.rfind("./", 0) == 0)
+			normalized = normalized.substr(2);
+		return normalized;
+	}
+
+	bool HasParentTraversalRuntime(const std::string& s)
+	{
+		std::filesystem::path p(s);
+		for (const auto& part : p)
+		{
+			if (part == "..")
+				return true;
 		}
+		return false;
+	}
+
+	bool IsAllowedLogicalPathRuntime(const std::string& s)
+	{
+		std::string lower = s;
+		for (char& c : lower)
+			c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+		return lower.rfind("assets/", 0) == 0 ||
+			lower.rfind("resource/", 0) == 0 ||
+			lower.rfind("cooked/", 0) == 0;
+	}
+
+	std::string ToLowerAsciiRuntime(std::string s)
+	{
+		for (char& c : s)
+			c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+		return s;
+	}
+
+	bool EndsWithAsciiRuntime(const std::string& s, const std::string& suffix)
+	{
+		if (s.size() < suffix.size()) return false;
+		return std::equal(suffix.rbegin(), suffix.rend(), s.rbegin());
+	}
+
+	std::string GetLowerExtensionRuntime(const std::string& path)
+	{
+		const std::string ext = std::filesystem::path(path).extension().string();
+		return ToLowerAsciiRuntime(ext);
+	}
+
+	std::string MakeFbxHashedKeyRuntime(const std::string& logicalPath)
+	{
+		std::string normalized = NormalizeLogicalPathRuntime(logicalPath);
+		if (normalized.empty())
+			return {};
+		std::string lower = ToLowerAsciiRuntime(normalized);
+		const std::uint64_t h = ResourceManager::HashString64(lower);
+		char hex[17] = {};
+		std::snprintf(hex, sizeof(hex), "%016llx", static_cast<unsigned long long>(h));
+		std::string baseName = std::filesystem::path(logicalPath).stem().string();
+		if (baseName.empty())
+			baseName = "fbx";
+		return baseName + "_" + std::string(hex, hex + 8);
+	}
+
+	bool IsAudioExtensionRuntime(const std::string& extLower)
+	{
+		return extLower == ".wav" || extLower == ".ogg" || extLower == ".mp3" ||
+			extLower == ".flac" || extLower == ".m4a" || extLower == ".aac";
+	}
+
+	void AppendPreloadArray(const nlohmann::json& arr, std::vector<std::string>& out)
+	{
+		for (const auto& v : arr)
+		{
+			if (!v.is_string())
+				continue;
+			std::string s = TrimAsciiRuntime(v.get<std::string>());
+			if (s.empty())
+				continue;
+			out.push_back(NormalizeLogicalPathRuntime(s));
+		}
+	}
+
+	bool ParsePreloadJsonText(const std::string& text, std::vector<std::string>& out)
+	{
+		out.clear();
+		if (text.empty())
+			return false;
+
+		nlohmann::json j;
+		try
+		{
+			j = nlohmann::json::parse(text);
+		}
+		catch (...)
+		{
+			return false;
+		}
+
+		if (j.is_array())
+		{
+			AppendPreloadArray(j, out);
+			return true;
+		}
+
+		if (j.contains("preload") && j["preload"].is_array())
+		{
+			AppendPreloadArray(j["preload"], out);
+			return true;
+		}
+
+		if (j.contains("startup") && j["startup"].is_array())
+		{
+			AppendPreloadArray(j["startup"], out);
+			return true;
+		}
+
+		return true;
+	}
+
+	struct PreloadContext
+	{
+		ResourceManager& resources;
+		SkinnedMeshRegistry& skinnedRegistry;
+		std::unordered_map<std::string, std::shared_ptr<const std::vector<std::uint8_t>>>& blobs;
+		ForwardRenderSystem* forward = nullptr;
+		DeferredRenderSystem* deferred = nullptr;
+		UnityVfxMeshRenderSystem* vfx = nullptr;
+		ID3D11RenderDevice* renderDevice = nullptr;
+		bool useForward = false;
+
+		enum class KeyMatch
+		{
+			Unknown,
+			Match,
+			Mismatch
+		};
+
+		KeyMatch CheckMeshKeyForSource(const std::string& meshKey, const std::string& fbxLogicalPath)
+		{
+			if (meshKey.empty())
+				return KeyMatch::Unknown;
+
+			FbxInstanceAsset asset{};
+			const std::filesystem::path assetPath = std::filesystem::path("Assets/Fbx") / (meshKey + ".fbxasset");
+			if (!LoadFbxInstanceAssetAuto(resources, assetPath, asset))
+				return KeyMatch::Unknown;
+
+			if (asset.sourceFbx.empty())
+				return KeyMatch::Unknown;
+
+			std::string a = ToLowerAsciiRuntime(NormalizeLogicalPathRuntime(asset.sourceFbx));
+			std::string b = ToLowerAsciiRuntime(NormalizeLogicalPathRuntime(fbxLogicalPath));
+			if (a.empty() || b.empty())
+				return KeyMatch::Unknown;
+
+			return (a == b) ? KeyMatch::Match : KeyMatch::Mismatch;
+		}
+
+		bool PreloadBlob(const std::string& path)
+		{
+			auto sp = resources.LoadSharedBinaryAuto(path);
+			if (!sp)
+				return false;
+			blobs[path] = sp;
+			return true;
+		}
+
+		bool PreloadTexture(const std::string& path)
+		{
+			bool ok = false;
+			if (useForward && forward)
+				ok = forward->PreloadTexture(path) || ok;
+			if (!useForward && deferred)
+				ok = deferred->PreloadTexture(path) || ok;
+			if (!ok && forward)
+				ok = forward->PreloadTexture(path) || ok;
+			if (!ok && deferred)
+				ok = deferred->PreloadTexture(path) || ok;
+			return ok;
+		}
+
+		bool PrecomputeAnimationForMesh(const std::string& meshKey, const std::shared_ptr<SkinnedMeshGPU>& mesh)
+		{
+			if (meshKey.empty())
+				return false;
+			if (!mesh || !mesh->sourceModel)
+				return false;
+			if (skinnedRegistry.GetPrecomputedAnimation(meshKey))
+				return true;
+			if (!mesh->sourceModel->HasAnimations())
+				return true;
+			if (mesh->sourceModel->GetBoneNames().empty())
+				return true;
+
+			auto anim = std::make_shared<::FbxAnimation>();
+			anim->InitMetadata(mesh->sourceModel->GetScenePtr());
+			anim->SetSharedContext(
+				mesh->sourceModel->GetScenePtr(),
+				mesh->sourceModel->GetNodeIndexOfName(),
+				&mesh->sourceModel->GetBoneNames(),
+				&mesh->sourceModel->GetBoneOffsets(),
+				&mesh->sourceModel->GetGlobalInverse());
+
+			const auto t = mesh->sourceModel->GetCurrentAnimationType();
+			if (t == FbxModel::AnimationType::Rigid) anim->SetType(::FbxAnimation::AnimType::Rigid);
+			else if (t == FbxModel::AnimationType::Skinned) anim->SetType(::FbxAnimation::AnimType::Skinned);
+			else anim->SetType(::FbxAnimation::AnimType::None);
+
+			skinnedRegistry.SetPrecomputedAnimation(meshKey, anim);
+			return true;
+		}
+
+		bool PreloadByType(const std::string& path, bool allowGpu)
+		{
+			const std::string lower = ToLowerAsciiRuntime(path);
+			const std::string ext = GetLowerExtensionRuntime(lower);
+			const bool hasDevice = allowGpu && renderDevice && renderDevice->GetDevice();
+			ID3D11Device* device = hasDevice ? renderDevice->GetDevice() : nullptr;
+
+			if (EndsWithAsciiRuntime(lower, "effect.json"))
+			{
+				if (allowGpu && vfx)
+				{
+					if (vfx->PreloadEffect(path))
+						return true;
+				}
+				return PreloadBlob(path);
+			}
+
+			if (ext == ".fbxasset")
+			{
+				if (allowGpu && device)
+				{
+					FbxInstanceAsset asset{};
+					if (LoadFbxInstanceAssetAuto(resources, std::filesystem::path(path), asset))
+					{
+						if (asset.meshAssetPath.empty())
+							return PreloadBlob(path);
+						if (!skinnedRegistry.Has(asset.meshAssetPath))
+						{
+							FbxImporter importer(resources, &skinnedRegistry);
+							skinnedRegistry.LoadFromFbxAsset(asset.meshAssetPath, path, resources, importer, device);
+						}
+						if (auto mesh = skinnedRegistry.Find(asset.meshAssetPath))
+							PrecomputeAnimationForMesh(asset.meshAssetPath, mesh);
+						return true;
+					}
+				}
+				return PreloadBlob(path);
+			}
+
+			if (ext == ".fbx")
+			{
+				if (allowGpu && device)
+				{
+					const std::string meshKey = std::filesystem::path(path).stem().string();
+					const std::string hashedKey = MakeFbxHashedKeyRuntime(path);
+					const auto baseMatch = CheckMeshKeyForSource(meshKey, path);
+					const auto hashMatch = CheckMeshKeyForSource(hashedKey, path);
+					auto TryPrecompute = [&](const std::string& key) -> bool
+						{
+							if (key.empty())
+								return false;
+							if (auto mesh = skinnedRegistry.Find(key))
+							{
+								PrecomputeAnimationForMesh(key, mesh);
+								return true;
+							}
+							return false;
+						};
+
+					if (hashMatch == KeyMatch::Match && !hashedKey.empty() && skinnedRegistry.Has(hashedKey))
+					{
+						TryPrecompute(hashedKey);
+						return true;
+					}
+					if (baseMatch == KeyMatch::Match && !meshKey.empty() && skinnedRegistry.Has(meshKey))
+					{
+						TryPrecompute(meshKey);
+						return true;
+					}
+					if (hashMatch != KeyMatch::Mismatch && !hashedKey.empty() && skinnedRegistry.Has(hashedKey))
+					{
+						TryPrecompute(hashedKey);
+						return true;
+					}
+					if (baseMatch != KeyMatch::Mismatch && !meshKey.empty() && skinnedRegistry.Has(meshKey))
+					{
+						TryPrecompute(meshKey);
+						return true;
+					}
+
+					FbxImporter importer(resources, &skinnedRegistry);
+					FbxImportResult res = importer.Import(device, std::filesystem::path(path), FbxImportOptions{});
+					if (!res.meshAssetPath.empty())
+					{
+						if (auto mesh = skinnedRegistry.Find(res.meshAssetPath))
+							PrecomputeAnimationForMesh(res.meshAssetPath, mesh);
+						return true;
+					}
+				}
+				return PreloadBlob(path);
+			}
+
+			if (IsAudioExtensionRuntime(ext))
+			{
+				const std::wstring key = WStringFromUtf8(path);
+				if (!key.empty())
+				{
+					if (Sound::LoadAuto(resources, key, std::filesystem::path(path), Sound::Type::SFX))
+						return true;
+				}
+				return PreloadBlob(path);
+			}
+
+			if (ResourceManager::IsImageLogicalPath(std::filesystem::path(path)))
+			{
+				if (ext != ".tga")
+				{
+					if (allowGpu && PreloadTexture(path))
+						return true;
+				}
+				return PreloadBlob(path);
+			}
+
+			return PreloadBlob(path);
+		}
+	};
 
 		void LoadLightingSettings(const std::filesystem::path& exeDir,
 			int& shadingMode,
@@ -338,13 +694,44 @@ namespace Alice
 		if (!InitializeWindowAndInput(owner, nCmdShow)) return false;
 		if (!InitializeRenderDevice()) return false;
 
+		// 방금 생성한 윈도우가 흰색으로 보이는 현상을 막기 위해
+		// 가능한 가장 이른 시점에 한 프레임이라도 그려둡니다.
+		if (m_renderDevice)
+		{
+			float clearColor[4] = { 0.0f, 0.0f, 0.0f, 1.0f };
+			m_renderDevice->BeginFrame(clearColor);
+			m_renderDevice->EndFrame();
+		}
+
 		if (!InitializeEditorCoreIfNeeded()) return false;
 
-		InitializeAudio();
-
-		if (!InitializeRenderSystems()) return false;
-		if (!InitializeUI()) return false;
-		if (!InitializeComputeEffectSystem()) return false;
+		if (m_editorMode)
+		{
+			InitializeAudio();
+			if (!InitializeRenderSystems()) return false;
+			if (!InitializeUI()) return false;
+			if (!InitializeComputeEffectSystem()) return false;
+		}
+		else
+		{
+			ALICE_LOG_INFO("[Loading] Initializing UI renderer...");
+			if (!InitializeUI())
+			{
+				ALICE_LOG_ERRORF("[Loading] InitializeUI failed.");
+				return false;
+			}
+			ALICE_LOG_INFO("[Loading] UI renderer initialized.");
+			if (!InitializePreloadAndLoadingScreen(exeDir))
+			{
+				if (m_initCanceled)
+				{
+					ALICE_LOG_INFO("[Loading] Initialization canceled by user.");
+					return true;
+				}
+				ALICE_LOG_ERRORF("[Loading] Loading screen stage failed.");
+				return false;
+			}
+		}
 
 		InitializeCameraAndScriptHotReload();
 
@@ -688,6 +1075,9 @@ namespace Alice
 		if (m_deferredRenderSystem && m_trailRenderSystem)
 			m_deferredRenderSystem->SetSwordRenderSystem(m_trailRenderSystem.get());
 
+		if (m_forwardRenderSystem)  m_forwardRenderSystem->SetUIRenderer(&m_aliceUIRenderer);
+		if (m_deferredRenderSystem) m_deferredRenderSystem->SetUIRenderer(&m_aliceUIRenderer);
+
 		return true;
 	}
 
@@ -719,6 +1109,421 @@ namespace Alice
 			ALICE_LOG_ERRORF("[Debug] ComputeEffectSystem Init Failed!");
 			return false;
 		}
+		return true;
+	}
+
+	bool Engine::Impl::InitializePreloadAndLoadingScreen(const std::filesystem::path& /*exeDir*/)
+	{
+		if (m_editorMode)
+			return true;
+
+		ALICE_LOG_INFO("[Loading] InitializePreloadAndLoadingScreen begin.");
+
+		// 1) Preload.json 로드
+		std::string preloadText;
+		bool hasPreload = m_resourceManager.LoadText("Assets/Startup/Preload.json", preloadText);
+		if (!hasPreload)
+			hasPreload = m_resourceManager.LoadText("Assets/Preload.json", preloadText);
+
+		std::vector<std::string> rawList;
+		if (hasPreload)
+		{
+			if (!ParsePreloadJsonText(preloadText, rawList))
+			{
+				ALICE_LOG_WARN("Preload.json parse failed. Preload list will be empty.");
+				rawList.clear();
+			}
+		}
+		else
+		{
+			ALICE_LOG_WARN("Preload.json not found. Loading screen will use empty list.");
+		}
+
+		// 2) 경로 검증 + 중복 제거
+		std::vector<std::string> filtered;
+		filtered.reserve(rawList.size());
+		std::unordered_set<std::string> seen;
+		for (const auto& entry : rawList)
+		{
+			std::string normalized = NormalizeLogicalPathRuntime(entry);
+			if (normalized.empty())
+				continue;
+			if (HasParentTraversalRuntime(normalized))
+			{
+				ALICE_LOG_WARN("Preload: skipped path with '..' : %s", normalized.c_str());
+				continue;
+			}
+			if (!IsAllowedLogicalPathRuntime(normalized))
+			{
+				ALICE_LOG_WARN("Preload: invalid path (must be Assets/Resource/Cooked): %s", normalized.c_str());
+				continue;
+			}
+
+			std::string key = normalized;
+			for (char& c : key)
+				c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+			if (seen.insert(key).second)
+				filtered.push_back(normalized);
+		}
+
+		// 3) 존재 확인
+		std::vector<std::string> preloadList;
+		preloadList.reserve(filtered.size());
+		for (const auto& path : filtered)
+		{
+			const std::filesystem::path resolved = m_resourceManager.Resolve(path);
+			std::error_code ec;
+			if (std::filesystem::exists(resolved, ec))
+			{
+				preloadList.push_back(path);
+			}
+			else
+			{
+				ALICE_LOG_WARN("Preload: missing file (skipped): %s (resolved: %s)",
+					path.c_str(), resolved.string().c_str());
+			}
+		}
+
+		ALICE_LOG_INFO("[Loading] Preload list ready. raw=%zu filtered=%zu valid=%zu",
+			rawList.size(), filtered.size(), preloadList.size());
+		PreloadContext preloadCtx{
+			m_resourceManager,
+			m_skinnedMeshRegistry,
+			m_preloadedBlobs,
+			m_forwardRenderSystem.get(),
+			m_deferredRenderSystem.get(),
+			m_unityVfxMeshRenderSystem.get(),
+			m_renderDevice.get(),
+			m_useForwardRendering
+		};
+
+		// 4) 렌더 장치가 없으면 UI 없이 프리로드만 수행
+		if (!m_renderDevice || !m_renderDevice->GetBackBufferRTV())
+		{
+			ALICE_LOG_WARN("[Loading] Render device not ready. Running preload without UI.");
+			InitializeAudio();
+			if (!InitializeRenderSystems()) return false;
+			if (!InitializeComputeEffectSystem()) return false;
+
+			for (const auto& path : preloadList)
+				preloadCtx.PreloadByType(path, false);
+			return true;
+		}
+
+		// 5) 로딩 UI 월드 구성
+		World loadingWorld;
+		auto CreateScreenWidget = [&](const char* name, float anchorX, float anchorY,
+			const DirectX::XMFLOAT2& size, int sortOrder)
+		{
+			EntityId e = loadingWorld.CreateEntity();
+			loadingWorld.SetEntityName(e, name);
+			auto& widget = loadingWorld.AddComponent<UIWidgetComponent>(e);
+			widget.widgetName = name;
+			widget.space = AliceUI::UISpace::Screen;
+
+			auto& t = loadingWorld.AddComponent<UITransformComponent>(e);
+			t.anchorMin = DirectX::XMFLOAT2(anchorX, anchorY);
+			t.anchorMax = DirectX::XMFLOAT2(anchorX, anchorY);
+			t.position = DirectX::XMFLOAT2(0.0f, 0.0f);
+			t.size = size;
+			t.useAlignment = true;
+			t.alignH = AliceUI::UIAlignH::Center;
+			t.alignV = AliceUI::UIAlignV::Center;
+			t.sortOrder = sortOrder;
+
+			loadingWorld.AddComponent<TransformComponent>(e);
+			return e;
+		};
+
+		// Banner
+		const EntityId bannerId = CreateScreenWidget("Loading_Banner", 0.5f, 0.42f,
+			DirectX::XMFLOAT2(720.0f, 360.0f), 0);
+		auto& bannerImg = loadingWorld.AddComponent<UIImageComponent>(bannerId);
+		bannerImg.texturePath = "Resource/Icon/AliceBanner.png";
+		bannerImg.preserveAspect = true;
+
+		// Status text
+		const EntityId statusId = CreateScreenWidget("Loading_Status", 0.5f, 0.65f,
+			DirectX::XMFLOAT2(640.0f, 40.0f), 1);
+		{
+			auto& statusText = loadingWorld.AddComponent<UITextComponent>(statusId);
+			statusText.fontPath = "Resource/Fonts/NotoSansKR-Regular.ttf";
+			statusText.fontSize = 24.0f;
+			statusText.alignH = AliceUI::UIAlignH::Center;
+			statusText.alignV = AliceUI::UIAlignV::Center;
+			statusText.text = "쉐이더 컴파일중.";
+		}
+
+		// Progress gauge
+		const EntityId gaugeId = CreateScreenWidget("Loading_Bar", 0.5f, 0.73f,
+			DirectX::XMFLOAT2(560.0f, 20.0f), 1);
+		{
+			auto& gauge = loadingWorld.AddComponent<UIGaugeComponent>(gaugeId);
+			gauge.normalized = true;
+			gauge.value = 0.0f;
+			gauge.displayedValue = 0.0f;
+			gauge.smoothing = 0.15f;
+			gauge.fillColor = DirectX::XMFLOAT4(0.2f, 0.9f, 0.2f, 1.0f);
+			gauge.backgroundColor = DirectX::XMFLOAT4(0.1f, 0.1f, 0.1f, 0.85f);
+		}
+
+		{
+			auto& gaugeFx = loadingWorld.AddComponent<UIEffectComponent>(gaugeId);
+			gaugeFx.glowEnabled = false;
+			gaugeFx.glowColor = DirectX::XMFLOAT4(1.0f, 1.0f, 1.0f, 1.0f);
+			gaugeFx.glowStrength = 0.25f;
+			gaugeFx.glowWidth = 0.25f;
+			gaugeFx.glowSpeed = 0.75f;
+		}
+
+		// Hint text
+		const EntityId hintId = CreateScreenWidget("Loading_Hint", 0.5f, 0.80f,
+			DirectX::XMFLOAT2(640.0f, 32.0f), 1);
+		{
+			auto& hintText = loadingWorld.AddComponent<UITextComponent>(hintId);
+			hintText.fontPath = "Resource/Fonts/NotoSansKR-Regular.ttf";
+			hintText.fontSize = 20.0f;
+			hintText.alignH = AliceUI::UIAlignH::Center;
+			hintText.alignV = AliceUI::UIAlignV::Center;
+			hintText.text.clear();
+		}
+
+		// 6) 로딩 화면 루프
+		using clock = std::chrono::steady_clock;
+		auto last = clock::now();
+		float dotTimer = 0.0f;
+		int dotIndex = 0;
+		const char* dotSeq[] = { ".", "..", "...", ".." };
+		float displayedProgress = 0.0f;
+		float targetProgress = 0.0f;
+
+		const float kAudioWeight = 0.05f;
+		const float kRenderWeight = 0.45f;
+		const float kComputeWeight = 0.15f;
+		float progressBase = 0.0f;
+
+		auto PumpMessages = [&]() -> bool
+		{
+			MSG msg{};
+			while (PeekMessage(&msg, nullptr, 0, 0, PM_REMOVE))
+			{
+				if (msg.message == WM_QUIT)
+				{
+					m_initCanceled = true;
+					ALICE_LOG_INFO("[Loading] WM_QUIT received. Canceling initialization.");
+					return false;
+				}
+				TranslateMessage(&msg);
+				DispatchMessage(&msg);
+			}
+			return true;
+		};
+
+		auto CalcDelta = [&]() -> float
+		{
+			const auto now = clock::now();
+			float dt = std::chrono::duration<float>(now - last).count();
+			last = now;
+			if (dt < 0.0f) dt = 0.0f;
+			if (dt > 0.1f) dt = 0.1f;
+			return dt;
+		};
+
+		auto UpdateLoadingUI = [&](float dt)
+		{
+			dotTimer += dt;
+			if (dotTimer >= 0.35f)
+			{
+				dotTimer = 0.0f;
+				dotIndex = (dotIndex + 1) % 4;
+			}
+			if (auto* statusText = loadingWorld.GetComponent<UITextComponent>(statusId))
+				statusText->text = std::string("쉐이더 컴파일중") + dotSeq[dotIndex];
+
+			const float speed = 3.5f;
+			const float t = std::clamp(dt * speed, 0.0f, 1.0f);
+			displayedProgress = displayedProgress + (targetProgress - displayedProgress) * t;
+			if (auto* gauge = loadingWorld.GetComponent<UIGaugeComponent>(gaugeId))
+				gauge->value = displayedProgress;
+		};
+
+		auto RenderFrame = [&](float dt, bool animate) -> bool
+		{
+			static int s_debugFrames = 2;
+			const bool debug = (s_debugFrames > 0);
+			if (debug)
+				ALICE_LOG_INFO("[Loading] RenderFrame begin (dt=%.4f, animate=%d)", dt, animate ? 1 : 0);
+
+			if (!PumpMessages())
+			{
+				if (debug)
+					ALICE_LOG_WARN("[Loading] PumpMessages failed.");
+				return false;
+			}
+			if (debug)
+				ALICE_LOG_INFO("[Loading] PumpMessages ok");
+
+			if (animate)
+				UpdateLoadingUI(dt);
+			if (debug)
+				ALICE_LOG_INFO("[Loading] UpdateLoadingUI ok");
+
+			m_inputSystem.Update(dt);
+			if (debug)
+				ALICE_LOG_INFO("[Loading] InputSystem.Update ok");
+
+			m_aliceUIRenderer.Update(loadingWorld, m_inputSystem, m_camera,
+				static_cast<float>(m_width), static_cast<float>(m_height), dt);
+			if (debug)
+				ALICE_LOG_INFO("[Loading] UIRenderer.Update ok");
+
+			float clearColor[4] = { 0.0f, 0.0f, 0.0f, 1.0f };
+			m_renderDevice->BeginFrame(clearColor);
+			if (debug)
+				ALICE_LOG_INFO("[Loading] BeginFrame ok");
+
+			m_aliceUIRenderer.RenderScreen(loadingWorld, m_camera,
+				m_renderDevice->GetBackBufferRTV(),
+				static_cast<float>(m_width), static_cast<float>(m_height));
+			if (debug)
+				ALICE_LOG_INFO("[Loading] RenderScreen ok");
+
+			m_renderDevice->EndFrame();
+			if (debug)
+				ALICE_LOG_INFO("[Loading] EndFrame ok");
+
+			if (debug)
+				--s_debugFrames;
+			return true;
+		};
+
+		auto AdvanceTo = [&](float nextTarget, float minSeconds) -> bool
+		{
+			targetProgress = std::clamp(nextTarget, 0.0f, 1.0f);
+			const auto endTime = clock::now() + std::chrono::duration<float>(std::max(0.0f, minSeconds));
+			while (clock::now() < endTime || displayedProgress + 0.001f < targetProgress)
+			{
+				float dt = CalcDelta();
+				if (!RenderFrame(dt, true))
+				{
+					ALICE_LOG_WARN("[Loading] RenderFrame failed during progress update.");
+					return false;
+				}
+				std::this_thread::sleep_for(std::chrono::milliseconds(8));
+			}
+			return true;
+		};
+
+		// 초기 프레임
+		if (!RenderFrame(CalcDelta(), true))
+		{
+			ALICE_LOG_WARN("[Loading] Initial frame render failed.");
+			return false;
+		}
+		if (!AdvanceTo(0.02f, 0.15f))
+			return false;
+
+		// 시스템 초기화 단계
+		ALICE_LOG_INFO("[Loading] Initializing audio...");
+		InitializeAudio();
+		ALICE_LOG_INFO("[Loading] Audio initialized.");
+		progressBase += kAudioWeight;
+		if (!AdvanceTo(progressBase, 0.12f))
+			return false;
+
+		ALICE_LOG_INFO("[Loading] Initializing render systems...");
+		if (!InitializeRenderSystems())
+		{
+			ALICE_LOG_ERRORF("[Loading] Render systems initialization failed.");
+			return false;
+		}
+		ALICE_LOG_INFO("[Loading] Render systems initialized.");
+		progressBase += kRenderWeight;
+		if (!AdvanceTo(progressBase, 0.20f))
+			return false;
+
+		ALICE_LOG_INFO("[Loading] Initializing compute effect system...");
+		if (!InitializeComputeEffectSystem())
+		{
+			ALICE_LOG_ERRORF("[Loading] Compute effect system initialization failed.");
+			return false;
+		}
+		ALICE_LOG_INFO("[Loading] Compute effect system initialized.");
+		progressBase += kComputeWeight;
+		if (!AdvanceTo(progressBase, 0.15f))
+			return false;
+
+		// 프리로드 단계
+		const size_t total = preloadList.size();
+		size_t loaded = 0;
+		const float preloadBase = progressBase;
+		const float preloadWeight = std::max(0.0f, 1.0f - preloadBase);
+
+		if (total == 0)
+		{
+			ALICE_LOG_INFO("[Loading] Preload list empty.");
+			progressBase = preloadBase + preloadWeight;
+			if (!AdvanceTo(progressBase, 0.15f))
+				return false;
+		}
+		else
+		{
+			ALICE_LOG_INFO("[Loading] Preloading %zu items...", total);
+			float stepTime = 0.015f;
+			if (total <= 6) stepTime = 0.08f;
+			else if (total <= 24) stepTime = 0.03f;
+
+			for (const auto& path : preloadList)
+			{
+				if (!preloadCtx.PreloadByType(path, true))
+				{
+					ALICE_LOG_WARN("Preload failed: %s", path.c_str());
+				}
+
+				++loaded;
+				const float frac = static_cast<float>(loaded) / static_cast<float>(total);
+				const float nextTarget = preloadBase + preloadWeight * frac;
+				if (!AdvanceTo(nextTarget, stepTime))
+					return false;
+			}
+			ALICE_LOG_INFO("[Loading] Preload finished.");
+		}
+
+		if (!AdvanceTo(1.0f, 0.10f))
+			return false;
+
+		// 완료 상태
+		displayedProgress = 1.0f;
+		targetProgress = 1.0f;
+		if (auto* gauge = loadingWorld.GetComponent<UIGaugeComponent>(gaugeId))
+			gauge->value = 1.0f;
+		if (auto* statusText = loadingWorld.GetComponent<UITextComponent>(statusId))
+			statusText->text = "쉐이더 컴파일 완료";
+		if (auto* hintText = loadingWorld.GetComponent<UITextComponent>(hintId))
+			hintText->text = "마우스를 클릭하여 시작";
+		if (auto* gaugeFx = loadingWorld.GetComponent<UIEffectComponent>(gaugeId))
+			gaugeFx->glowEnabled = true;
+
+		float glowTime = 0.0f;
+		while (true)
+		{
+			float dt = CalcDelta();
+			glowTime += dt;
+			if (auto* gaugeFx = loadingWorld.GetComponent<UIEffectComponent>(gaugeId))
+				gaugeFx->glowStrength = 0.2f + 0.15f * (0.5f + 0.5f * std::sin(glowTime * 3.0f));
+
+			if (!RenderFrame(dt, false))
+			{
+				ALICE_LOG_WARN("[Loading] RenderFrame failed during completion wait.");
+				return false;
+			}
+
+			if (m_inputSystem.IsMouseButtonPressed(0))
+				break;
+
+			std::this_thread::sleep_for(std::chrono::milliseconds(8));
+		}
+
 		return true;
 	}
 

--- a/Engine/src/Runtime/Engine/EngineWindow.cpp
+++ b/Engine/src/Runtime/Engine/EngineWindow.cpp
@@ -11,9 +11,9 @@ namespace Alice
 	{
 		// ============================================= 아이콘 로드 =============================================
 		// CMake에서 exe에 임베딩된 아이콘을 사용합니다.
-		constexpr int kAppIconId = 101;
-		HICON hIconBig = LoadIconW(m_hInstance, MAKEINTRESOURCEW(kAppIconId));
-		HICON hIconSmall = LoadIconW(m_hInstance, MAKEINTRESOURCEW(kAppIconId));
+		constexpr wchar_t kAppIconName[] = L"IDI_ICON1";
+		HICON hIconBig = LoadIconW(m_hInstance, kAppIconName);
+		HICON hIconSmall = LoadIconW(m_hInstance, kAppIconName);
 
 		// ============================================= 윈도우 클래스 등록 =============================================
 		// C++ 구조체 제로 초기화({})를 활용하여 불필요한 0 대입 생략

--- a/Engine/src/Runtime/Gameplay/Animation/AnimBlueprintSystem.h
+++ b/Engine/src/Runtime/Gameplay/Animation/AnimBlueprintSystem.h
@@ -63,6 +63,8 @@ namespace Alice
                     rt = Runtime{};
                     rt.meshKey = skinned.meshAssetPath;
                     rt.anim.InitMetadata(mesh->sourceModel->GetScenePtr());
+                    if (auto pre = m_registry.GetPrecomputedAnimation(rt.meshKey))
+                        rt.anim.CopyPrecomputedFrom(*pre);
                     rt.anim.SetSharedContext(
                         mesh->sourceModel->GetScenePtr(),
                         mesh->sourceModel->GetNodeIndexOfName(),

--- a/Engine/src/Runtime/Gameplay/Animation/SkinnedAnimationSystem.h
+++ b/Engine/src/Runtime/Gameplay/Animation/SkinnedAnimationSystem.h
@@ -2,6 +2,7 @@
 
 #include <unordered_map>
 #include <string>
+#include <cmath>
 
 #include <DirectXMath.h>
 
@@ -102,6 +103,13 @@ namespace Alice
                 // 시간 진행(엔티티 단위)
                 if (animComp->playing && dtSec > 0.0)
                     animComp->timeSec += dtSec * (double)animComp->speed;
+
+                // 클립 끝에 도달하면 0으로 롤오버 (루프)
+                const double clipDur = rt.anim.GetClipDurationSec(animComp->clipIndex);
+                if (clipDur > 0.0 && animComp->timeSec >= clipDur)
+                {
+                    animComp->timeSec = std::fmod(animComp->timeSec, clipDur);
+                }
 
                 rt.anim.SetCurrentIndex(animComp->clipIndex);
                 rt.anim.SetTimeSec(animComp->timeSec);

--- a/Engine/src/Runtime/Gameplay/Animation/SkinnedAnimationSystem.h
+++ b/Engine/src/Runtime/Gameplay/Animation/SkinnedAnimationSystem.h
@@ -72,6 +72,8 @@ namespace Alice
                     rt = Runtime{};
                     rt.meshKey = skinned.meshAssetPath;
                     rt.anim.InitMetadata(mesh->sourceModel->GetScenePtr());
+                    if (auto pre = m_registry.GetPrecomputedAnimation(rt.meshKey))
+                        rt.anim.CopyPrecomputedFrom(*pre);
 
                     // 공유 컨텍스트 바인딩(+프리컴퓨트)
                     rt.anim.SetSharedContext(

--- a/Engine/src/Runtime/Importing/FbxAnimation.cpp
+++ b/Engine/src/Runtime/Importing/FbxAnimation.cpp
@@ -119,10 +119,15 @@ void FbxAnimation::SetSharedContext(
 
     // Precompute all clips to avoid per-frame evaluation
     // Default to 30 samples per second to balance memory/quality
-    if (m_Scene && m_BoneNames && m_BoneOffsets && m_GlobalInverse)
+    if (m_Precomputed.empty() && m_Scene && m_BoneNames && m_BoneOffsets && m_GlobalInverse)
     {
         PrecomputeAll(m_Scene, m_NodeIndexOfName, *m_BoneNames, *m_BoneOffsets, *m_GlobalInverse, 30);
     }
+}
+
+void FbxAnimation::CopyPrecomputedFrom(const FbxAnimation& src)
+{
+    m_Precomputed = src.m_Precomputed;
 }
 
 static void RebuildChannelMapIfNeeded(const aiScene* scene, int currentClip, const std::unordered_map<std::string,int>& nodeIndexOfName, std::vector<const aiNodeAnim*>& out)

--- a/Engine/src/Runtime/Importing/FbxAnimation.h
+++ b/Engine/src/Runtime/Importing/FbxAnimation.h
@@ -41,6 +41,7 @@ public:
 		const std::vector<std::string>* boneNames,
 		const std::vector<DirectX::XMFLOAT4X4>* boneOffsets,
 		const DirectX::XMFLOAT4X4* globalInverse);
+	void CopyPrecomputedFrom(const FbxAnimation& src);
 	void SetType(AnimType t) { m_Type = t; }
 	AnimType GetType() const { return m_Type; }
 

--- a/Engine/src/Runtime/Importing/FbxImporter.cpp
+++ b/Engine/src/Runtime/Importing/FbxImporter.cpp
@@ -38,6 +38,84 @@ namespace Alice
             for (char& c : s) c = ToLowerChar(static_cast<unsigned char>(c));
         }
 
+        inline std::string NormalizeLogicalKey(std::string s)
+        {
+            std::replace(s.begin(), s.end(), '\\', '/');
+            if (s.rfind("./", 0) == 0)
+                s = s.substr(2);
+            std::filesystem::path p(s);
+            std::string normalized = p.lexically_normal().generic_string();
+            if (normalized.rfind("./", 0) == 0)
+                normalized = normalized.substr(2);
+            ToLowerInPlace(normalized);
+            return normalized;
+        }
+
+        inline std::string MakeMeshKeyHashSuffix(std::string_view normalizedLower)
+        {
+            const std::uint64_t h = ResourceManager::HashString64(normalizedLower);
+            char hex[17] = {};
+            std::snprintf(hex, sizeof(hex), "%016llx", static_cast<unsigned long long>(h));
+            return std::string(hex, hex + 8);
+        }
+
+        inline std::string ResolveUniqueMeshKey(ResourceManager& rm,
+                                               SkinnedMeshRegistry* registry,
+                                               const std::string& baseName,
+                                               const std::filesystem::path& logicalPath)
+        {
+            if (baseName.empty())
+                return baseName;
+
+            const std::string logicalKey = NormalizeLogicalKey(logicalPath.generic_string());
+            if (logicalKey.empty())
+                return baseName;
+
+            namespace fs = std::filesystem;
+            bool collision = false;
+
+            const fs::path fbxAssetLogical = fs::path("Assets/Fbx") / (baseName + ".fbxasset");
+            FbxInstanceAsset existing;
+            bool hasExistingAsset = false;
+
+            if (rm.IsGameMode())
+            {
+                hasExistingAsset = LoadFbxInstanceAssetAuto(rm, fbxAssetLogical, existing);
+            }
+            else
+            {
+                const fs::path fbxAssetPath = rm.Resolve(fbxAssetLogical);
+                std::error_code ec;
+                if (fs::exists(fbxAssetPath, ec))
+                {
+                    if (LoadFbxInstanceAsset(fbxAssetPath, existing))
+                    {
+                        hasExistingAsset = true;
+                    }
+                    else
+                    {
+                        collision = true;
+                    }
+                }
+                else if (registry && registry->Has(baseName))
+                {
+                    collision = true;
+                }
+            }
+
+            if (hasExistingAsset)
+            {
+                const std::string existingKey = NormalizeLogicalKey(existing.sourceFbx);
+                if (existingKey.empty() || existingKey != logicalKey)
+                    collision = true;
+            }
+
+            if (!collision)
+                return baseName;
+
+            return baseName + "_" + MakeMeshKeyHashSuffix(logicalKey);
+        }
+
         // 간단한 이미지 확장자 체크 함수입니다.
         inline bool IsImageFile(const std::filesystem::path& path)
         {
@@ -297,6 +375,8 @@ namespace Alice
             // 절대 경로를 논리 경로로 변환
             resolvedLogical = ResourceManager::NormalizeResourcePathAbsoluteToLogical(resolvedLogical);
         }
+        const std::string meshKey = ResolveUniqueMeshKey(m_resources, m_meshRegistry, baseName, resolvedLogical);
+        const std::string modelName = meshKey.empty() ? baseName : meshKey;
 
         if (fileExists)
         {
@@ -380,7 +460,6 @@ namespace Alice
             // 애니메이션 재생/클립 목록을 위해 원본 컨텍스트를 유지합니다.
             gpu->sourceModel = model;
 
-            const std::string meshKey = baseName;
             m_meshRegistry->Register(meshKey, gpu);
 
             ALICE_LOG_INFO("[FbxImporter] Registered mesh key=\"%s\" stride=%u indexCount=%u subsets=%zu mats=%zu\n",
@@ -404,9 +483,9 @@ namespace Alice
             
             // Diffuse/BaseColor 텍스처 (우선순위: DIFFUSE > BASE_COLOR)
             // fbxPath는 원본 경로(절대 또는 논리), resolved는 실제 파일 위치
-            std::string albedoPath = ProcessTexture(m_resources, scene, mat, aiTextureType_DIFFUSE, resolved, baseName, "D", embeddedCounter);
+            std::string albedoPath = ProcessTexture(m_resources, scene, mat, aiTextureType_DIFFUSE, resolved, modelName, "D", embeddedCounter);
             if (albedoPath.empty())
-                albedoPath = ProcessTexture(m_resources, scene, mat, aiTextureType_BASE_COLOR, resolved, baseName, "D", embeddedCounter);
+                albedoPath = ProcessTexture(m_resources, scene, mat, aiTextureType_BASE_COLOR, resolved, modelName, "D", embeddedCounter);
 
             materialAlbedoPaths[mi] = std::move(albedoPath);
         }
@@ -421,7 +500,7 @@ namespace Alice
 
         for (std::size_t i = 0; i < matCount; ++i)
         {
-            fs::path matPath = matDir / (baseName + "_" + std::to_string(i) + ".mat");
+            fs::path matPath = matDir / (modelName + "_" + std::to_string(i) + ".mat");
 
             MaterialComponent matComp;
             matComp.color = DirectX::XMFLOAT3(1.0f, 1.0f, 1.0f);
@@ -443,12 +522,12 @@ namespace Alice
             MaterialFile::Save(matPath, matComp);
 
             // 상대 경로로 변환하여 저장
-            fs::path matPathRelative = fs::path("Assets/Materials") / (baseName + "_" + std::to_string(i) + ".mat");
+            fs::path matPathRelative = fs::path("Assets/Materials") / (modelName + "_" + std::to_string(i) + ".mat");
             result.materialAssetPaths.push_back(matPathRelative.generic_string());
         }
 
         // 5) 메시 자산의 논리 경로는 FBX 이름을 그대로 사용합니다.
-        result.meshAssetPath = baseName;
+        result.meshAssetPath = meshKey.empty() ? baseName : meshKey;
 
         // 6) 에디터/World 에서 사용할 인스턴스 에셋(.fbxasset)을 생성합니다.
         //    - 언리얼의 SkeletalMesh 에셋 비슷한 개념으로, FBX 원본과 머티리얼을 묶어 둡니다.
@@ -457,7 +536,7 @@ namespace Alice
             std::error_code ec;
             fs::create_directories(fbxAssetDir, ec);
 
-            fs::path fbxAssetPath = fbxAssetDir / (baseName + ".fbxasset");
+            fs::path fbxAssetPath = fbxAssetDir / (result.meshAssetPath + ".fbxasset");
 
             FbxInstanceAsset asset;
             asset.sourceFbx = NormalizeToResourceLogical(resolvedLogical);
@@ -467,7 +546,7 @@ namespace Alice
             if (!SaveFbxInstanceAsset(fbxAssetPath, asset)) return result;
 
             // 상대 경로로 변환하여 저장 D:\\Github\\AliceRenderer\\Assets\\Materials -> (Assets/Fbx/... 형식)
-            fs::path fbxAssetPathRelative = fs::path("Assets/Fbx") / (baseName + ".fbxasset");
+            fs::path fbxAssetPathRelative = fs::path("Assets/Fbx") / (result.meshAssetPath + ".fbxasset");
             result.instanceAssetPath = fbxAssetPathRelative.generic_string();
         }
 

--- a/Engine/src/Runtime/Rendering/DebugDrawComponentSystem.cpp
+++ b/Engine/src/Runtime/Rendering/DebugDrawComponentSystem.cpp
@@ -3,6 +3,9 @@
 
 #include "Runtime/Rendering/Components/DebugDrawBoxComponent.h"
 #include "Runtime/Rendering/Components/DecalComponent.h"
+#include "Runtime/Rendering/Components/PointLightComponent.h"
+#include "Runtime/Rendering/Components/SpotLightComponent.h"
+#include "Runtime/Rendering/Components/RectLightComponent.h"
 #include "Runtime/Audio/Components/SoundBoxComponent.h"
 #include "Runtime/ECS/Components/TransformComponent.h"
 #include "Runtime/Gameplay/Combat/WeaponTraceComponent.h"
@@ -112,6 +115,54 @@ namespace Alice
                 XMFLOAT3 p2 = { center.x, center.y + radius * std::cos(a2), center.z + radius * std::sin(a2) };
                 dbg.AddLine(p1, p2, color);
             }
+        }
+
+        void DrawCone(DebugDrawSystem& dbg,
+                      const XMFLOAT3& apex,
+                      const XMVECTOR& forward,
+                      const XMVECTOR& right,
+                      const XMVECTOR& up,
+                      float length,
+                      float radius,
+                      const XMFLOAT4& color)
+        {
+            if (length <= 0.0f || radius <= 0.0f)
+                return;
+
+            const int segments = 16;
+            const float angleStep = XM_2PI / segments;
+
+            XMVECTOR apexV = XMLoadFloat3(&apex);
+            XMVECTOR baseCenter = XMVectorAdd(apexV, XMVectorScale(forward, length));
+
+            XMFLOAT3 first{};
+            XMFLOAT3 prev{};
+            for (int i = 0; i <= segments; ++i)
+            {
+                float a = i * angleStep;
+                XMVECTOR offset = XMVectorAdd(
+                    XMVectorScale(right, std::cos(a) * radius),
+                    XMVectorScale(up, std::sin(a) * radius));
+                XMVECTOR p = XMVectorAdd(baseCenter, offset);
+                XMFLOAT3 cur{};
+                XMStoreFloat3(&cur, p);
+
+                if (i == 0)
+                {
+                    first = cur;
+                }
+                else
+                {
+                    dbg.AddLine(prev, cur, color);
+                }
+
+                // cone side
+                dbg.AddLine(apex, cur, color);
+                prev = cur;
+            }
+
+            // close the base circle explicitly
+            dbg.AddLine(prev, first, color);
         }
 
         void DrawCapsule(DebugDrawSystem& dbg, const XMFLOAT3& center, float radius, float halfHeight, bool alignYAxis, const XMVECTOR& rot, const XMFLOAT4& color)
@@ -407,6 +458,82 @@ namespace Alice
                 : XMFLOAT4(decal.color.x, decal.color.y, decal.color.z, 1.0f);
 
             DrawBox(*target, center, halfExtents, r, color);
+        }
+
+        // Light debug draw
+        for (const auto& [entityId, light] : world.GetComponents<PointLightComponent>())
+        {
+            if (!light.enabled)
+                continue;
+
+            const TransformComponent* tr = world.GetComponent<TransformComponent>(entityId);
+            if (!tr || !tr->enabled) continue;
+
+            const float range = std::max(0.0f, light.range);
+            if (range <= 0.0f) continue;
+
+            const XMFLOAT4 color = (entityId == selectedEntity)
+                ? XMFLOAT4(1.0f, 1.0f, 0.2f, 1.0f)
+                : XMFLOAT4(light.color.x, light.color.y, light.color.z, 1.0f);
+
+            DrawSphere(*target, tr->position, range, color);
+        }
+
+        for (const auto& [entityId, light] : world.GetComponents<SpotLightComponent>())
+        {
+            if (!light.enabled)
+                continue;
+
+            const TransformComponent* tr = world.GetComponent<TransformComponent>(entityId);
+            if (!tr || !tr->enabled) continue;
+
+            const float range = std::max(0.0f, light.range);
+            if (range <= 0.0f) continue;
+
+            const float angleRad = XMConvertToRadians(std::max(0.0f, light.outerAngleDeg));
+            const float radius = std::tan(angleRad * 0.5f) * range;
+            if (radius <= 0.0f) continue;
+
+            const XMFLOAT4 color = (entityId == selectedEntity)
+                ? XMFLOAT4(1.0f, 0.6f, 0.2f, 1.0f)
+                : XMFLOAT4(light.color.x, light.color.y, light.color.z, 1.0f);
+
+            const XMVECTOR rot = EulerToQuaternion(tr->rotation);
+            const XMVECTOR forward = XMVector3Normalize(RotateVector(XMVectorSet(0.0f, 0.0f, 1.0f, 0.0f), rot));
+            const XMVECTOR right = XMVector3Normalize(RotateVector(XMVectorSet(1.0f, 0.0f, 0.0f, 0.0f), rot));
+            const XMVECTOR up = XMVector3Normalize(RotateVector(XMVectorSet(0.0f, 1.0f, 0.0f, 0.0f), rot));
+
+            DrawCone(*target, tr->position, forward, right, up, range, radius, color);
+        }
+
+        for (const auto& [entityId, light] : world.GetComponents<RectLightComponent>())
+        {
+            if (!light.enabled)
+                continue;
+
+            const TransformComponent* tr = world.GetComponent<TransformComponent>(entityId);
+            if (!tr || !tr->enabled) continue;
+
+            const float range = std::max(0.0f, light.range);
+            const float halfW = std::max(0.0f, light.width * 0.5f);
+            const float halfH = std::max(0.0f, light.height * 0.5f);
+            if (halfW <= 0.0f || halfH <= 0.0f || range <= 0.0f)
+                continue;
+
+            const XMFLOAT4 color = (entityId == selectedEntity)
+                ? XMFLOAT4(0.2f, 1.0f, 1.0f, 1.0f)
+                : XMFLOAT4(light.color.x, light.color.y, light.color.z, 1.0f);
+
+            const XMVECTOR rot = EulerToQuaternion(tr->rotation);
+            const XMVECTOR forward = XMVector3Normalize(RotateVector(XMVectorSet(0.0f, 0.0f, 1.0f, 0.0f), rot));
+
+            XMFLOAT3 center = tr->position;
+            center.x += XMVectorGetX(forward) * (range * 0.5f);
+            center.y += XMVectorGetY(forward) * (range * 0.5f);
+            center.z += XMVectorGetZ(forward) * (range * 0.5f);
+
+            XMFLOAT3 halfExtents{ halfW, halfH, range * 0.5f };
+            DrawBox(*target, center, halfExtents, rot, color);
         }
 
         // Collider debug draw

--- a/Engine/src/Runtime/Rendering/DeferredRenderSystem.cpp
+++ b/Engine/src/Runtime/Rendering/DeferredRenderSystem.cpp
@@ -4715,6 +4715,11 @@ namespace Alice
         return srv.Get();
     }
 
+    bool DeferredRenderSystem::PreloadTexture(const std::string& path)
+    {
+        return GetOrCreateTexture(path) != nullptr;
+    }
+
     void DeferredRenderSystem::GetPostProcessParams(float& outExposure, float& outMaxHDRNits) const
     {
         outExposure = m_postProcessParams.exposure;

--- a/Engine/src/Runtime/Rendering/DeferredRenderSystem.h
+++ b/Engine/src/Runtime/Rendering/DeferredRenderSystem.h
@@ -49,6 +49,10 @@ namespace Alice
         /// 스키닝 메시 레지스트리를 주입합니다.
         void SetSkinnedMeshRegistry(SkinnedMeshRegistry* registry) { m_skinnedRegistry = registry; }
 
+        /// 텍스처를 미리 로드하여 캐시에 보관합니다.
+        /// - 경로가 비거나 로딩 실패 시 false 반환.
+        bool PreloadTexture(const std::string& path);
+
         /// 디퍼드 렌더링을 수행합니다.
         /// @param world ECS 월드
         /// @param camera 카메라

--- a/Engine/src/Runtime/Rendering/ForwardRenderSystem.cpp
+++ b/Engine/src/Runtime/Rendering/ForwardRenderSystem.cpp
@@ -1056,6 +1056,11 @@ namespace Alice
         return srv.Get();
     }
 
+    bool ForwardRenderSystem::PreloadTexture(const std::string& path)
+    {
+        return GetOrCreateTexture(path) != nullptr;
+    }
+
     void ForwardRenderSystem::UpdatePerObjectCB(const XMMATRIX& world,
                                                 const XMMATRIX& view,
                                                 const XMMATRIX& projection,

--- a/Engine/src/Runtime/Rendering/ForwardRenderSystem.h
+++ b/Engine/src/Runtime/Rendering/ForwardRenderSystem.h
@@ -47,6 +47,10 @@ namespace Alice
 
         /// 스키닝 메시 메타데이터(서브셋/스켈레톤)를 조회하기 위한 레지스트리를 주입합니다.
         void SetSkinnedMeshRegistry(SkinnedMeshRegistry* registry) { m_skinnedRegistry = registry; }
+
+        /// 텍스처를 미리 로드하여 캐시에 보관합니다.
+        /// - 경로가 비거나 로딩 실패 시 false 반환.
+        bool PreloadTexture(const std::string& path);
         
     public:
         /// 단일 엔티티(예: 큐브)와 스키닝 메시들을 함께 렌더링합니다.

--- a/Engine/src/Runtime/Rendering/SkinnedMeshRegistry.h
+++ b/Engine/src/Runtime/Rendering/SkinnedMeshRegistry.h
@@ -12,6 +12,7 @@
 
 // FbxModel은 전역 네임스페이스(Runtime/Importing/FbxModel.h) 에 정의되어 있습니다.
 class FbxModel;
+class FbxAnimation;
 
 namespace Alice
 {
@@ -84,8 +85,27 @@ namespace Alice
                               FbxImporter& importer,
                               ID3D11Device* device);
 
+        void SetPrecomputedAnimation(const std::string& meshKey,
+                                     std::shared_ptr<::FbxAnimation> anim)
+        {
+            if (meshKey.empty())
+                return;
+            if (!anim)
+                return;
+            m_precomputedAnims[meshKey] = std::move(anim);
+        }
+
+        std::shared_ptr<::FbxAnimation> GetPrecomputedAnimation(const std::string& meshKey) const
+        {
+            auto it = m_precomputedAnims.find(meshKey);
+            if (it == m_precomputedAnims.end())
+                return nullptr;
+            return it->second;
+        }
+
     private:
         std::unordered_map<std::string, std::shared_ptr<SkinnedMeshGPU>> m_meshes;
+        std::unordered_map<std::string, std::shared_ptr<::FbxAnimation>> m_precomputedAnims;
     };
 }
 

--- a/Engine/src/Runtime/Rendering/UnityVfxMeshRenderSystem.cpp
+++ b/Engine/src/Runtime/Rendering/UnityVfxMeshRenderSystem.cpp
@@ -1756,6 +1756,58 @@ float4 main(PSInput input) : SV_TARGET
         return true;
     }
 
+    bool UnityVfxMeshRenderSystem::PreloadEffect(const std::string& effectPath)
+    {
+        if (effectPath.empty())
+            return false;
+
+        const EffectCache* cache = GetEffectCache(effectPath);
+        if (!cache || !cache->valid)
+            return false;
+
+        const std::string baseDir = std::filesystem::path(effectPath).parent_path().generic_string();
+        bool ok = true;
+
+        for (const auto& node : cache->meshNodes)
+        {
+            if (!node.materialPath.empty())
+            {
+                MaterialGpu mat{};
+                ok = EnsureMaterialLoaded(baseDir, node.materialPath, mat) && ok;
+            }
+            if (!node.meshPath.empty())
+            {
+                MeshGpu mesh{};
+                ok = EnsureMeshLoaded(node.meshPath, mesh) && ok;
+            }
+        }
+
+        for (const auto& node : cache->billboardNodes)
+        {
+            if (!node.materialPath.empty())
+            {
+                MaterialGpu mat{};
+                ok = EnsureMaterialLoaded(baseDir, node.materialPath, mat) && ok;
+            }
+        }
+
+        for (const auto& def : cache->emitters)
+        {
+            if (!def.materialPath.empty())
+            {
+                MaterialGpu mat{};
+                ok = EnsureMaterialLoaded(baseDir, def.materialPath, mat) && ok;
+            }
+            if (def.meshRenderer && !def.meshPath.empty())
+            {
+                MeshGpu mesh{};
+                ok = EnsureMeshLoaded(def.meshPath, mesh) && ok;
+            }
+        }
+
+        return ok;
+    }
+
     bool UnityVfxMeshRenderSystem::EnsureTrailVertexBuffer(size_t vertexCount)
     {
         if (vertexCount == 0) return false;

--- a/Engine/src/Runtime/Rendering/UnityVfxMeshRenderSystem.h
+++ b/Engine/src/Runtime/Rendering/UnityVfxMeshRenderSystem.h
@@ -35,6 +35,7 @@ namespace Alice
 
         bool Initialize();
         void Render(const World& world, const Camera& camera, float dtSec);
+        bool PreloadEffect(const std::string& effectPath);
 
     private:
         struct MeshGpu

--- a/Engine/src/Runtime/Resources/Prefab.cpp
+++ b/Engine/src/Runtime/Resources/Prefab.cpp
@@ -6,6 +6,7 @@
 #include "Runtime/ECS/ComponentRegistry.h"  // RTTR 등록 코드 포함
 #include "Runtime/Resources/Serialization/JsonRttr.h"
 #include "Runtime/Resources/ResourceManager.h"
+#include "Runtime/Importing/FbxAsset.h"
 
 #include "Runtime/ECS/World.h"
 #include "Runtime/Scripting/Components/ScriptComponent.h"
@@ -77,6 +78,7 @@ namespace Alice
 
             static World* g_DefaultWorld = nullptr;
             static ResourceManager* g_DefaultResources = nullptr;
+            static ResourceManager* ResolvePrefabResourceManager();
 
             // 프로젝트 루트 경로를 구하는 헬퍼 함수
             static std::filesystem::path GetProjectRoot()
@@ -127,6 +129,29 @@ namespace Alice
                 }
 
                 return path;
+            }
+
+            static void ResolveSkinnedMeshPathsForLoad(SkinnedMeshComponent& skinned)
+            {
+                if (skinned.instanceAssetPath.empty() && !skinned.meshAssetPath.empty())
+                {
+                    const std::filesystem::path inferred = std::filesystem::path("Assets/Fbx") / (skinned.meshAssetPath + ".fbxasset");
+                    skinned.instanceAssetPath = inferred.generic_string();
+                }
+
+                if (!skinned.instanceAssetPath.empty())
+                {
+                    ResourceManager* resources = ResolvePrefabResourceManager();
+                    if (resources)
+                    {
+                        FbxInstanceAsset asset{};
+                        if (LoadFbxInstanceAssetAuto(*resources, skinned.instanceAssetPath, asset))
+                        {
+                            if (!asset.meshAssetPath.empty())
+                                skinned.meshAssetPath = asset.meshAssetPath;
+                        }
+                    }
+                }
             }
 
             static std::uint64_t ParseGuidOrZero(const JsonRttr::json& j)
@@ -702,6 +727,8 @@ namespace Alice
                     rttr::instance instTmp = tmp;
                     if (!JsonRttr::FromJsonObject(instTmp, *itSM))
                         return false;
+
+                    ResolveSkinnedMeshPathsForLoad(tmp);
 
                     if (!tmp.meshAssetPath.empty())
                     {

--- a/Engine/src/Runtime/Resources/ResourceManager.cpp
+++ b/Engine/src/Runtime/Resources/ResourceManager.cpp
@@ -26,6 +26,41 @@ namespace
         std::uint64_t originalSize;
         std::uint32_t payloadSize;
     };
+
+    std::string NormalizeRelForHash(std::string_view rel)
+    {
+        std::string s(rel);
+        std::replace(s.begin(), s.end(), '\\', '/');
+        if (s.rfind("./", 0) == 0)
+            s = s.substr(2);
+        std::filesystem::path p(s);
+        std::string normalized = p.lexically_normal().generic_string();
+        if (normalized.rfind("./", 0) == 0)
+            normalized = normalized.substr(2);
+        std::transform(normalized.begin(), normalized.end(), normalized.begin(),
+                       [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+        return normalized;
+    }
+
+    std::uint64_t HashRelNormalized(std::string_view rel)
+    {
+        const std::string normalized = NormalizeRelForHash(rel);
+        return Alice::ResourceManager::HashString64(normalized);
+    }
+
+    std::uint64_t HashRelLegacy(std::string_view rel)
+    {
+        return Alice::ResourceManager::HashString64(rel);
+    }
+
+    std::filesystem::path Chunk0PathFromFileId(const std::filesystem::path& baseDir, std::uint64_t fileId)
+    {
+        char hex[17] = {};
+        std::snprintf(hex, sizeof(hex), "%016llx", static_cast<unsigned long long>(fileId));
+        const std::string hexStr = hex;
+        const std::filesystem::path dir = baseDir / "Chunks" / hexStr.substr(0, 2) / hexStr;
+        return (dir / "c0000.alice").lexically_normal();
+    }
 }
 
 namespace Alice
@@ -184,7 +219,17 @@ namespace Alice
             if (m_gameMode)
             {
                 const std::string rest = s.substr(std::string_view("Assets/").size());
-                return Chunk0PathForMetasRel(rest);
+                auto path = Chunk0PathForMetasRel(rest);
+                std::error_code ec;
+                if (!std::filesystem::exists(path, ec))
+                {
+                    const std::uint64_t legacyId = HashRelLegacy(rest);
+                    auto legacyPath = Chunk0PathFromFileId(MetasDir(), legacyId);
+                    ec.clear();
+                    if (std::filesystem::exists(legacyPath, ec))
+                        return legacyPath;
+                }
+                return path;
             }
             return (m_rootDir / p).lexically_normal();
         }
@@ -200,7 +245,17 @@ namespace Alice
             if (m_gameMode)
             {
                 const std::string rest = s.substr(std::string_view("Resource/").size());
-                return Chunk0PathForResourceRel(rest);
+                auto path = Chunk0PathForResourceRel(rest);
+                std::error_code ec;
+                if (!std::filesystem::exists(path, ec))
+                {
+                    const std::uint64_t legacyId = HashRelLegacy(rest);
+                    auto legacyPath = Chunk0PathFromFileId(CookedDir(), legacyId);
+                    ec.clear();
+                    if (std::filesystem::exists(legacyPath, ec))
+                        return legacyPath;
+                }
+                return path;
             }
             return (m_rootDir / p).lexically_normal();
         }
@@ -359,39 +414,40 @@ namespace Alice
     std::filesystem::path ResourceManager::Chunk0PathForResourceRel(std::string_view resourceRel) const
     {
         // fileId = rel 문자열 해시 (폴더구조 노출 방지용)
-        const std::uint64_t fileId = HashString64(resourceRel);
-
-        char hex[17] = {};
-        std::snprintf(hex, sizeof(hex), "%016llx", static_cast<unsigned long long>(fileId));
-        const std::string hexStr = hex;
-
-        const std::filesystem::path dir = CookedDir() / "Chunks" / hexStr.substr(0, 2) / hexStr;
-        return (dir / "c0000.alice").lexically_normal();
+        const std::uint64_t fileId = HashRelNormalized(resourceRel);
+        return Chunk0PathFromFileId(CookedDir(), fileId);
     }
 
     std::filesystem::path ResourceManager::Chunk0PathForMetasRel(std::string_view assetsRel) const
     {
-        const std::uint64_t fileId = HashString64(assetsRel);
-
-        char hex[17] = {};
-        std::snprintf(hex, sizeof(hex), "%016llx", static_cast<unsigned long long>(fileId));
-        const std::string hexStr = hex;
-
-        const std::filesystem::path dir = MetasDir() / "Chunks" / hexStr.substr(0, 2) / hexStr;
-        return (dir / "c0000.alice").lexically_normal();
+        const std::uint64_t fileId = HashRelNormalized(assetsRel);
+        return Chunk0PathFromFileId(MetasDir(), fileId);
     }
 
     std::shared_ptr<const std::vector<std::uint8_t>> ResourceManager::LoadMetasChunksByRel(std::string_view assetsRel) const
     {
         namespace fs = std::filesystem;
 
-        const std::uint64_t fileId = HashString64(assetsRel);
-        fs::path c0 = Chunk0PathForMetasRel(assetsRel);
+        const std::uint64_t normId = HashRelNormalized(assetsRel);
+        fs::path c0 = Chunk0PathFromFileId(MetasDir(), normId);
+        std::uint64_t fileId = normId;
         if (!fs::exists(c0))
         {
-            ALICE_LOG_ERRORF("ResourceManager: missing metas chunk0 for Assets/%s -> \"%s\"",
-                             std::string(assetsRel).c_str(), c0.string().c_str());
-            return nullptr;
+            const std::uint64_t legacyId = HashRelLegacy(assetsRel);
+            fs::path legacyC0 = Chunk0PathFromFileId(MetasDir(), legacyId);
+            if (fs::exists(legacyC0))
+            {
+                ALICE_LOG_WARN("ResourceManager: metas chunk0 not found with normalized hash. Falling back to legacy hash for Assets/%s",
+                               std::string(assetsRel).c_str());
+                c0 = legacyC0;
+                fileId = legacyId;
+            }
+            else
+            {
+                ALICE_LOG_ERRORF("ResourceManager: missing metas chunk0 for Assets/%s -> \"%s\"",
+                                 std::string(assetsRel).c_str(), c0.string().c_str());
+                return nullptr;
+            }
         }
 
         struct ChunkReader
@@ -471,13 +527,26 @@ namespace Alice
     {
         namespace fs = std::filesystem;
 
-        const std::uint64_t fileId = HashString64(resourceRel);
-        fs::path c0 = Chunk0PathForResourceRel(resourceRel);
+        const std::uint64_t normId = HashRelNormalized(resourceRel);
+        fs::path c0 = Chunk0PathFromFileId(CookedDir(), normId);
+        std::uint64_t fileId = normId;
         if (!fs::exists(c0))
         {
-            ALICE_LOG_ERRORF("ResourceManager: missing chunk0 for Resource/%s -> \"%s\"",
-                             std::string(resourceRel).c_str(), c0.string().c_str());
-            return nullptr;
+            const std::uint64_t legacyId = HashRelLegacy(resourceRel);
+            fs::path legacyC0 = Chunk0PathFromFileId(CookedDir(), legacyId);
+            if (fs::exists(legacyC0))
+            {
+                ALICE_LOG_WARN("ResourceManager: chunk0 not found with normalized hash. Falling back to legacy hash for Resource/%s",
+                               std::string(resourceRel).c_str());
+                c0 = legacyC0;
+                fileId = legacyId;
+            }
+            else
+            {
+                ALICE_LOG_ERRORF("ResourceManager: missing chunk0 for Resource/%s -> \"%s\"",
+                                 std::string(resourceRel).c_str(), c0.string().c_str());
+                return nullptr;
+            }
         }
 
         struct ChunkReader
@@ -724,7 +793,7 @@ namespace Alice
             if (ec) { ec.clear(); continue; }
 
             const std::string relStr = rel.generic_string(); // fileId는 이 문자열로 결정
-            const std::uint64_t fileId = HashString64(relStr);
+            const std::uint64_t fileId = HashRelNormalized(relStr);
 
             char hex[17] = {};
             std::snprintf(hex, sizeof(hex), "%016llx", static_cast<unsigned long long>(fileId));

--- a/Engine/src/Runtime/Resources/ResourceManager.h
+++ b/Engine/src/Runtime/Resources/ResourceManager.h
@@ -133,6 +133,9 @@ namespace Alice
         /// 절대 경로를 논리 경로로 정규화 (public 유틸)
         static std::filesystem::path NormalizeResourcePathAbsoluteToLogical(const std::filesystem::path& p);
 
+        /// 경로/문자열 해시 (청크/키 계산용)
+        static std::uint64_t HashString64(std::string_view s);
+
     private:
         /// 매우 단순한 XOR 기반 스트림 암·복호화
         void XorCrypt(std::vector<std::uint8_t>& data) const;
@@ -141,7 +144,6 @@ namespace Alice
         static std::filesystem::path NormalizeLegacyDotDot(const std::filesystem::path& p);
         static std::filesystem::path ToAlicePath(std::filesystem::path p);
         static std::uint64_t Fnv1a64Bytes(const std::uint8_t* data, std::size_t size);
-        static std::uint64_t HashString64(std::string_view s);
         static std::uint64_t ComputeBufferHashSampled(const std::vector<std::uint8_t>& data);
 
         std::shared_ptr<const std::vector<std::uint8_t>> LoadResourceChunksByRel(std::string_view resourceRel) const;

--- a/Engine/src/Runtime/Resources/SceneFile.cpp
+++ b/Engine/src/Runtime/Resources/SceneFile.cpp
@@ -6,6 +6,7 @@
 #include "Runtime/ECS/ComponentRegistry.h"  // RTTR 등록 코드 포함
 #include "Runtime/Resources/Serialization/JsonRttr.h"
 #include "Runtime/Resources/ResourceManager.h"
+#include "Runtime/Importing/FbxAsset.h"
 #include "Runtime/Foundation/Logger.h"
 #include "Runtime/Foundation/ThreadSafety.h"
 #include "Runtime/ECS/Components/IDComponent.h"
@@ -91,6 +92,25 @@ namespace Alice
             static std::mt19937_64 rng{ std::random_device{}() };
             static std::uniform_int_distribution<std::uint64_t> dist;
             return dist(rng);
+        }
+
+        void ResolveSkinnedMeshPathsForLoad(SkinnedMeshComponent& skinned)
+        {
+            if (skinned.instanceAssetPath.empty() && !skinned.meshAssetPath.empty())
+            {
+                const std::filesystem::path inferred = std::filesystem::path("Assets/Fbx") / (skinned.meshAssetPath + ".fbxasset");
+                skinned.instanceAssetPath = inferred.generic_string();
+            }
+
+            if (!skinned.instanceAssetPath.empty())
+            {
+                FbxInstanceAsset asset{};
+                if (LoadFbxInstanceAssetAuto(ResourceManager::Get(), skinned.instanceAssetPath, asset))
+                {
+                    if (!asset.meshAssetPath.empty())
+                        skinned.meshAssetPath = asset.meshAssetPath;
+                }
+            }
         }
 
         // GUID 파싱 (JSON string 또는 number)
@@ -1061,6 +1081,8 @@ namespace Alice
                 SkinnedMeshComponent tmp;
                 rttr::instance instTmp = tmp;
                 if (!JsonRttr::FromJsonObject(instTmp, *itSM)) return false;
+
+                ResolveSkinnedMeshPathsForLoad(tmp);
 
                 if (!tmp.meshAssetPath.empty())
                 {


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #

## 📝 작업 내용
- [x] Skinned Mesh 인스펙터에 Browse... 추가로 FBX/FBXAsset 직접 선택 가능하게 하기
- [x] Skinned Mesh 인스펙터에 Clear 버튼 추가하기
- [x] Skinned Mesh 섹션을 접기/펼치기(기본 열림)로 변경하기
- [x] Animation Status 상단에 상태 라벨 표시: SkinnedAnimation: 초록색, AdvancedAnimation: 파란색으로 표시하기
- [x] Material 탭을 접기/펼치기(기본 열림)로 변경하기
- [x] Camera > Animation 탭: Clip 이름을 표시하고 애니메이션 클립에 Copy 버튼 추가하기
- [x] 클립 종료 시 시간 0으로 돌아오게 하기
- [x] 포스트 프로세스 볼륨을 더 쉽게 만들 수 있게 하기
- [x] 라이팅에 디버그 드로우 추가하기

## 🔬 테스트 방법 (없으면 삭제)
- 

## 📸 스크린샷 (선택)


<img width="2002" height="1165" alt="image" src="https://github.com/user-attachments/assets/8321b037-f955-4cdc-a881-82dc151f2e90" />


<img width="2002" height="1165" alt="image" src="https://github.com/user-attachments/assets/d385f7d1-ab2a-4cbc-b238-9b99d139303a" />

<img width="2002" height="1165" alt="image" src="https://github.com/user-attachments/assets/d9cfc877-619f-4133-bb6a-00482b5b0a08" />

<img width="2002" height="1165" alt="image" src="https://github.com/user-attachments/assets/40bcf6d4-ad12-4189-8858-6f942e23a579" />

<img width="2002" height="1165" alt="image" src="https://github.com/user-attachments/assets/13e7548c-97c5-4849-83a2-9f99091ee91a" />



## ✅ 체크리스트
- [x] 빌드가 에러 없이 정상적으로 되나요?
- [x] 불필요한 로그나 주석을 제거했나요?
- [x] 코딩 컨벤션을 지켰나요?