### PR TITLE
#39 카메라잘림연출

### DIFF
--- a/Assets/Scenes/Camera/CameraHalfCut.scene
+++ b/Assets/Scenes/Camera/CameraHalfCut.scene
@@ -1,0 +1,458 @@
+{
+    "entities": [
+        {
+            "Scripts": [
+                {
+                    "enabled": true,
+                    "name": "CameraHalfCutDemo",
+                    "props": {
+                        "m_cutVfxEulerOffsetDeg": {
+                            "x": 0.0,
+                            "y": 0.0,
+                            "z": 0.0
+                        },
+                        "m_cutVfxAnchorAName": "LeftCube",
+                        "m_cutVfxAnchorBName": "RightCube",
+                        "m_cutVfxBaseAlpha": 1.0,
+                        "m_cutVfxBaseIntensity": 1.0,
+                        "m_cutVfxBaseSpawnRate": 1.0,
+                        "m_cutVfxDespawnDelaySec": 0.800000011920929,
+                        "m_cutVfxFadeOutSec": 0.2199999988079071,
+                        "m_cutVfxForwardDistance": 9.0,
+                        "m_cutVfxUseAnchorMidpoint": true,
+                        "m_cutVfxLocalOffset": {
+                            "x": 0.0,
+                            "y": -0.3499999940395355,
+                            "z": 0.0
+                        },
+                        "m_cutVfxMidpointOffset": {
+                            "x": 0.0,
+                            "y": 0.0,
+                            "z": 0.0
+                        },
+                        "m_cutVfxPrefabPath": "Assets/Prefabs/(04)Charging.prefab",
+                        "m_cutVfxScale": {
+                            "x": 0.75,
+                            "y": 0.75,
+                            "z": 0.75
+                        },
+                        "m_cutVfxTriggerSec": 0.07999999821186066,
+                        "m_cutVfxForceOneShot": false,
+                        "m_angleDeg": 12.0,
+                        "m_attackSec": 0.07999999821186066,
+                        "m_autoCreateVolume": true,
+                        "m_cameraName": "MainCamera",
+                        "m_feather": 0.0020000000949949026,
+                        "m_holdSec": 0.05000000074505806,
+                        "m_lineOffset": 0.0,
+                        "m_peakAmount": 0.07999999821186066,
+                        "m_peakBloomGaussianIntensity": 2.200000047683716,
+                        "m_peakBloomIntensity": 2.5999999046325684,
+                        "m_peakBloomKnee": 0.6499999761581421,
+                        "m_peakBloomRadius": 1.7999999523162842,
+                        "m_peakBloomThreshold": 0.3499999940395355,
+                        "m_peakExposure": 3.5,
+                        "m_postProcessVolumeName": "CameraHalfCutVolume",
+                        "m_releaseSec": 0.2199999988079071,
+                        "m_shakeAmplitude": 0.15000000596046448,
+                        "m_shakeDecay": 2.200000047683716,
+                        "m_shakeDuration": 0.23000000417232513,
+                        "m_shakeFrequency": 30.0,
+                        "m_spawnCutVfx": true,
+                        "m_splitFxEnabled": true,
+                        "m_splitFxIntensity": 1.850000023841858,
+                        "m_splitFxSpeed": 44.0,
+                        "m_splitFxTimeScale": 1.0,
+                        "m_splitFxWidth": 0.012000000104308128,
+                        "m_triggerKey": 1,
+                        "m_useFovCurveAsset": true,
+                        "m_fovCurvePath": "Assets/Curves/UI/FadeInOut.uicurve",
+                        "m_fovCurveTimeScale": 1.0,
+                        "m_fovCurveValueScale": 1.0,
+                        "m_fovCurveValueBias": 0.0,
+                        "m_fovCurveClamp01": true,
+                        "m_volumePriority": 500,
+                        "m_zoomFov": 18.0
+                    }
+                }
+            ],
+            "Transform": {
+                "enabled": true,
+                "position": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "rotation": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "scale": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "z": 1.0
+                },
+                "visible": true
+            },
+            "guid": "6875178953805225652",
+            "name": "CameraHalfCutController"
+        },
+        {
+            "Material": {
+                "albedoTexturePath": "",
+                "alpha": 1.0,
+                "ambientOcclusion": 1.0,
+                "assetPath": "Assets/Materials/Cube_0.mat",
+                "color": {
+                    "x": 0.949999988079071,
+                    "y": 0.3499999940395355,
+                    "z": 0.3499999940395355
+                },
+                "envDiffuseStrength": 1.0,
+                "envSpecularStrength": 1.0,
+                "metalness": 0.0,
+                "normalStrength": 1.0,
+                "outlineColor": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "outlineWidth": 0.0,
+                "roughness": 0.5,
+                "shadingMode": -1,
+                "shadowStrength": 1.0,
+                "toonPbrBlur": false,
+                "toonPbrCut1": 0.20000000298023224,
+                "toonPbrCut2": 0.5,
+                "toonPbrCut3": 0.949999988079071,
+                "toonPbrLevel1": 0.10000000149011612,
+                "toonPbrLevel1Alpha": 1.0,
+                "toonPbrLevel2": 0.4000000059604645,
+                "toonPbrLevel2Alpha": 1.0,
+                "toonPbrLevel3": 0.699999988079071,
+                "toonPbrLevel3Alpha": 1.0,
+                "toonPbrRampIntensity": 0.0,
+                "toonPbrStrength": 1.0,
+                "toonSelfShadowStrength": 1.0,
+                "transparent": false
+            },
+            "SkinnedAnimation": {
+                "clipIndex": 0,
+                "playing": false,
+                "speed": 1.0,
+                "timeSec": 0.0
+            },
+            "SkinnedMesh": {
+                "boneCount": 1,
+                "instanceAssetPath": "Assets/Fbx/Cube.fbxasset",
+                "meshAssetPath": "Cube"
+            },
+            "Transform": {
+                "enabled": true,
+                "position": {
+                    "x": -1.2000000476837158,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "rotation": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "scale": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "z": 1.0
+                },
+                "visible": true
+            },
+            "guid": "17782471007914569014",
+            "name": "LeftCube"
+        },
+        {
+            "Material": {
+                "albedoTexturePath": "",
+                "alpha": 1.0,
+                "ambientOcclusion": 1.0,
+                "assetPath": "Assets/Materials/Cube_0.mat",
+                "color": {
+                    "x": 0.25,
+                    "y": 0.800000011920929,
+                    "z": 1.0
+                },
+                "envDiffuseStrength": 1.0,
+                "envSpecularStrength": 1.0,
+                "metalness": 0.0,
+                "normalStrength": 1.0,
+                "outlineColor": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "outlineWidth": 0.0,
+                "roughness": 0.5,
+                "shadingMode": -1,
+                "shadowStrength": 1.0,
+                "toonPbrBlur": false,
+                "toonPbrCut1": 0.20000000298023224,
+                "toonPbrCut2": 0.5,
+                "toonPbrCut3": 0.949999988079071,
+                "toonPbrLevel1": 0.10000000149011612,
+                "toonPbrLevel1Alpha": 1.0,
+                "toonPbrLevel2": 0.4000000059604645,
+                "toonPbrLevel2Alpha": 1.0,
+                "toonPbrLevel3": 0.699999988079071,
+                "toonPbrLevel3Alpha": 1.0,
+                "toonPbrRampIntensity": 0.0,
+                "toonPbrStrength": 1.0,
+                "toonSelfShadowStrength": 1.0,
+                "transparent": false
+            },
+            "SkinnedAnimation": {
+                "clipIndex": 0,
+                "playing": false,
+                "speed": 1.0,
+                "timeSec": 0.0
+            },
+            "SkinnedMesh": {
+                "boneCount": 1,
+                "instanceAssetPath": "Assets/Fbx/Cube.fbxasset",
+                "meshAssetPath": "Cube"
+            },
+            "Transform": {
+                "enabled": true,
+                "position": {
+                    "x": 1.2000000476837158,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "rotation": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "scale": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "z": 1.0
+                },
+                "visible": true
+            },
+            "guid": "64660960338499047",
+            "name": "RightCube"
+        },
+        {
+            "Material": {
+                "albedoTexturePath": "",
+                "alpha": 1.0,
+                "ambientOcclusion": 1.0,
+                "assetPath": "Assets/Materials/Cube_0.mat",
+                "color": {
+                    "x": 0.23000000417232513,
+                    "y": 0.23000000417232513,
+                    "z": 0.23000000417232513
+                },
+                "envDiffuseStrength": 1.0,
+                "envSpecularStrength": 1.0,
+                "metalness": 0.0,
+                "normalStrength": 1.0,
+                "outlineColor": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "outlineWidth": 0.0,
+                "roughness": 0.8999999761581421,
+                "shadingMode": -1,
+                "shadowStrength": 1.0,
+                "toonPbrBlur": false,
+                "toonPbrCut1": 0.20000000298023224,
+                "toonPbrCut2": 0.5,
+                "toonPbrCut3": 0.949999988079071,
+                "toonPbrLevel1": 0.10000000149011612,
+                "toonPbrLevel1Alpha": 1.0,
+                "toonPbrLevel2": 0.4000000059604645,
+                "toonPbrLevel2Alpha": 1.0,
+                "toonPbrLevel3": 0.699999988079071,
+                "toonPbrLevel3Alpha": 1.0,
+                "toonPbrRampIntensity": 0.0,
+                "toonPbrStrength": 1.0,
+                "toonSelfShadowStrength": 1.0,
+                "transparent": false
+            },
+            "SkinnedAnimation": {
+                "clipIndex": 0,
+                "playing": false,
+                "speed": 1.0,
+                "timeSec": 0.0
+            },
+            "SkinnedMesh": {
+                "boneCount": 1,
+                "instanceAssetPath": "Assets/Fbx/Cube.fbxasset",
+                "meshAssetPath": "Cube"
+            },
+            "Transform": {
+                "enabled": true,
+                "position": {
+                    "x": 0.0,
+                    "y": -1.100000023841858,
+                    "z": 0.0
+                },
+                "rotation": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "scale": {
+                    "x": 12.0,
+                    "y": 0.30000001192092896,
+                    "z": 5.0
+                },
+                "visible": true
+            },
+            "guid": "7785286238415942333",
+            "name": "Ground"
+        },
+        {
+            "Camera": {
+                "FOV": 45.0,
+                "Far Plane": 5000.0,
+                "Near Plane": 0.10000000149011612,
+                "aspectOverride": 0.0,
+                "primary": true,
+                "useAspectOverride": false
+            },
+            "Transform": {
+                "enabled": true,
+                "position": {
+                    "x": 0.0,
+                    "y": 2.4052348136901855,
+                    "z": -9.0
+                },
+                "rotation": {
+                    "x": 0.2313976287841797,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "scale": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "z": 1.0
+                },
+                "visible": true
+            },
+            "guid": "9804082005314421307",
+            "name": "MainCamera"
+        },
+        {
+            "DebugDrawBox": {
+                "boundsMax": {
+                    "x": 5.0,
+                    "y": 5.0,
+                    "z": 5.0
+                },
+                "boundsMin": {
+                    "x": -5.0,
+                    "y": -5.0,
+                    "z": -5.0
+                },
+                "color": {
+                    "w": 1.0,
+                    "x": 0.0,
+                    "y": 1.0,
+                    "z": 0.0
+                },
+                "depthTest": false,
+                "enabled": true
+            },
+            "PostProcessVolume": {
+                "blendRadius": 0.0,
+                "blendWeight": 1.0,
+                "boxSize": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "z": 1.0
+                },
+                "priority": 500,
+                "referenceObjectName": "",
+                "settings": {
+                    "bOverride_BloomDownsample": false,
+                    "bOverride_BloomGaussianIntensity": false,
+                    "bOverride_BloomIntensity": false,
+                    "bOverride_BloomKnee": false,
+                    "bOverride_BloomRadius": false,
+                    "bOverride_BloomThreshold": false,
+                    "bOverride_ColorGradingContrast": false,
+                    "bOverride_ColorGradingGain": false,
+                    "bOverride_ColorGradingGamma": false,
+                    "bOverride_ColorGradingSaturation": false,
+                    "bOverride_Exposure": false,
+                    "bOverride_MaxHDRNits": false,
+                    "bOverride_SplitAmount": true,
+                    "bOverride_SplitAngleDeg": true,
+                    "bOverride_SplitFeather": true,
+                    "bOverride_SplitLineOffset": true,
+                    "bloomDownsample": 2,
+                    "bloomGaussianIntensity": 1.0,
+                    "bloomIntensity": 0.0,
+                    "bloomKnee": 0.5,
+                    "bloomRadius": 1.0,
+                    "bloomThreshold": 1.0,
+                    "contrast": {
+                        "x": 1.0,
+                        "y": 1.0,
+                        "z": 1.0
+                    },
+                    "exposure": 0.0,
+                    "gain": {
+                        "x": 1.0,
+                        "y": 1.0,
+                        "z": 1.0
+                    },
+                    "gamma": {
+                        "x": 1.0,
+                        "y": 1.0,
+                        "z": 1.0
+                    },
+                    "maxHDRNits": 1000.0,
+                    "saturation": {
+                        "x": 1.0,
+                        "y": 1.0,
+                        "z": 1.0
+                    },
+                    "splitAmount": 0.0,
+                    "splitAngleDeg": 12.0,
+                    "splitFeather": 0.0020000000949949026,
+                    "splitLineOffset": 0.0
+                },
+                "shape": "Box",
+                "unbound": true,
+                "useReferenceObject": false
+            },
+            "Transform": {
+                "enabled": true,
+                "position": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "rotation": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "scale": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "z": 1.0
+                },
+                "visible": true
+            },
+            "guid": "8963134015403500598",
+            "name": "CameraHalfCutVolume"
+        }
+    ],
+    "sceneName": "CameraHalfCut",
+    "version": 1
+}

--- a/Assets/Scripts/Camera/CameraHalfCutDemo.cpp
+++ b/Assets/Scripts/Camera/CameraHalfCutDemo.cpp
@@ -1,0 +1,876 @@
+#include "CameraHalfCutDemo.h"
+
+#include <algorithm>
+#include <cmath>
+
+#include "Runtime/Scripting/ScriptFactory.h"
+#include "Runtime/Foundation/Logger.h"
+#include "Runtime/ECS/World.h"
+#include "Runtime/ECS/GameObject.h"
+#include "Runtime/ECS/Components/TransformComponent.h"
+#include "Runtime/Resources/Prefab.h"
+#include "Runtime/Resources/ResourceManager.h"
+#include "Runtime/Rendering/Components/CameraComponent.h"
+#include "Runtime/Rendering/Components/CameraShakeComponent.h"
+#include "Runtime/Rendering/Components/PostProcessVolumeComponent.h"
+#include "Runtime/Rendering/Components/UnityVfxComponent.h"
+#include "Runtime/Rendering/Components/ComputeEffectComponent.h"
+
+namespace Alice
+{
+    REGISTER_SCRIPT(CameraHalfCutDemo);
+
+    namespace
+    {
+        float Saturate(float v)
+        {
+            return std::clamp(v, 0.0f, 1.0f);
+        }
+
+        float EaseOutCubic(float t)
+        {
+            t = Saturate(t);
+            const float inv = 1.0f - t;
+            return 1.0f - inv * inv * inv;
+        }
+
+        float EaseInCubic(float t)
+        {
+            t = Saturate(t);
+            return t * t * t;
+        }
+
+        float Lerp(float a, float b, float t)
+        {
+            t = Saturate(t);
+            return a + (b - a) * t;
+        }
+
+        float LerpUnclamped(float a, float b, float t)
+        {
+            return a + (b - a) * t;
+        }
+    }
+
+    void CameraHalfCutDemo::Start()
+    {
+        EnsurePostProcessVolume();
+        ResolveTargetCamera();
+        CaptureBaseline();
+        RefreshFovCurveAsset();
+        ResetAll();
+        m_elapsedSec = 0.0f;
+        m_playing = false;
+        m_shakeTriggered = false;
+        m_vfxTriggered = false;
+    }
+
+    void CameraHalfCutDemo::Update(float deltaTime)
+    {
+        if (m_loadedFovCurvePath != Get_m_fovCurvePath())
+        {
+            RefreshFovCurveAsset();
+        }
+
+        auto* input = Input();
+        if (!input)
+            return;
+
+        if (input->GetKeyDown(static_cast<KeyCode>(Get_m_triggerKey())))
+        {
+            if (m_playing)
+            {
+                m_playing = false;
+                ResetAll();
+            }
+
+            World* world = GetWorld();
+            if (world && m_activeCutVfx != InvalidEntityId && world->GetComponent<TransformComponent>(m_activeCutVfx))
+            {
+                world->DestroyEntity(m_activeCutVfx);
+            }
+            m_activeCutVfx = InvalidEntityId;
+            m_vfxTriggered = false;
+
+            if (EnsurePostProcessVolume() && ResolveTargetCamera())
+            {
+                CaptureBaseline();
+                PrepareOverrides();
+                m_playing = true;
+                m_shakeTriggered = false;
+                m_vfxTriggered = false;
+                m_elapsedSec = 0.0f;
+                ApplyEffectState(0.0f);
+            }
+        }
+
+        if (!m_playing)
+            return;
+
+        m_elapsedSec += std::max(0.0f, deltaTime);
+        const float totalSec = GetTotalDuration();
+
+        if (totalSec <= 0.0f)
+        {
+            m_playing = false;
+            ResetAll();
+            return;
+        }
+
+        ApplyEffectState(m_elapsedSec);
+
+        if (m_elapsedSec >= totalSec)
+        {
+            m_playing = false;
+            ResetAll();
+        }
+    }
+
+    void CameraHalfCutDemo::OnDisable()
+    {
+        m_playing = false;
+        ResetAll();
+    }
+
+    void CameraHalfCutDemo::OnDestroy()
+    {
+        m_playing = false;
+        ResetAll();
+    }
+
+    bool CameraHalfCutDemo::EnsurePostProcessVolume()
+    {
+        World* world = GetWorld();
+        if (!world)
+            return false;
+
+        auto* current = (m_volumeEntity == InvalidEntityId)
+            ? nullptr
+            : world->GetComponent<PostProcessVolumeComponent>(m_volumeEntity);
+
+        if (!current)
+        {
+            const std::string name = Get_m_postProcessVolumeName();
+            if (!name.empty())
+            {
+                GameObject go = world->FindGameObject(name);
+                if (go.IsValid())
+                {
+                    auto* found = world->GetComponent<PostProcessVolumeComponent>(go.id());
+                    if (found)
+                    {
+                        m_volumeEntity = go.id();
+                        current = found;
+                    }
+                }
+            }
+        }
+
+        if (!current && Get_m_autoCreateVolume())
+        {
+            const EntityId id = world->CreateEntity();
+            m_volumeEntity = id;
+            world->SetEntityName(id, Get_m_postProcessVolumeName().empty() ? "CameraHalfCutVolume" : Get_m_postProcessVolumeName());
+
+            auto& tr = world->AddComponent<TransformComponent>(id);
+            tr.enabled = true;
+            tr.visible = true;
+            tr.position = { 0.0f, 0.0f, 0.0f };
+            tr.rotation = { 0.0f, 0.0f, 0.0f };
+            tr.scale = { 1.0f, 1.0f, 1.0f };
+
+            auto& ppv = world->AddComponent<PostProcessVolumeComponent>(id);
+            ppv.unbound = true;
+            ppv.blendWeight = 1.0f;
+            ppv.priority = Get_m_volumePriority();
+            ppv.blendRadius = 0.0f;
+            ppv.boxSize = { 1.0f, 1.0f, 1.0f };
+            current = &ppv;
+        }
+
+        if (!current)
+        {
+            if (!m_warnedMissingVolume)
+            {
+                ALICE_LOG_WARN("[CameraHalfCutDemo] PostProcessVolume '%s' not found. (autoCreate=%s)",
+                    Get_m_postProcessVolumeName().c_str(),
+                    Get_m_autoCreateVolume() ? "true" : "false");
+                m_warnedMissingVolume = true;
+            }
+            return false;
+        }
+
+        m_warnedMissingVolume = false;
+        current->unbound = true;
+        current->blendWeight = 1.0f;
+        current->priority = Get_m_volumePriority();
+        return true;
+    }
+
+    bool CameraHalfCutDemo::ResolveTargetCamera()
+    {
+        World* world = GetWorld();
+        if (!world)
+            return false;
+
+        if (m_cameraEntity != InvalidEntityId)
+        {
+            if (world->GetComponent<CameraComponent>(m_cameraEntity))
+                return true;
+            m_cameraEntity = InvalidEntityId;
+        }
+
+        if (world->GetComponent<CameraComponent>(GetOwnerId()))
+        {
+            m_cameraEntity = GetOwnerId();
+            return true;
+        }
+
+        const std::string cameraName = Get_m_cameraName();
+        if (!cameraName.empty())
+        {
+            GameObject go = world->FindGameObject(cameraName);
+            if (go.IsValid() && world->GetComponent<CameraComponent>(go.id()))
+            {
+                m_cameraEntity = go.id();
+                return true;
+            }
+        }
+
+        for (const auto& [id, cam] : world->GetComponents<CameraComponent>())
+        {
+            if (cam.primary)
+            {
+                m_cameraEntity = id;
+                return true;
+            }
+        }
+
+        for (const auto& [id, _] : world->GetComponents<CameraComponent>())
+        {
+            m_cameraEntity = id;
+            return true;
+        }
+
+        return false;
+    }
+
+    void CameraHalfCutDemo::CaptureBaseline()
+    {
+        World* world = GetWorld();
+        if (!world)
+            return;
+
+        if (EnsurePostProcessVolume() && m_volumeEntity != InvalidEntityId)
+        {
+            auto* ppv = world->GetComponent<PostProcessVolumeComponent>(m_volumeEntity);
+            if (ppv)
+            {
+                const auto& s = ppv->settings;
+                m_ppvBaseline.valid = true;
+
+                m_ppvBaseline.bOverrideSplitAmount = s.bOverride_SplitAmount;
+                m_ppvBaseline.bOverrideSplitAngleDeg = s.bOverride_SplitAngleDeg;
+                m_ppvBaseline.bOverrideSplitLineOffset = s.bOverride_SplitLineOffset;
+                m_ppvBaseline.bOverrideSplitFeather = s.bOverride_SplitFeather;
+                m_ppvBaseline.bOverrideSplitFxIntensity = s.bOverride_SplitFxIntensity;
+                m_ppvBaseline.bOverrideSplitFxWidth = s.bOverride_SplitFxWidth;
+                m_ppvBaseline.bOverrideSplitFxSpeed = s.bOverride_SplitFxSpeed;
+                m_ppvBaseline.bOverrideSplitFxTimeSec = s.bOverride_SplitFxTimeSec;
+
+                m_ppvBaseline.bOverrideExposure = s.bOverride_Exposure;
+                m_ppvBaseline.bOverrideBloomThreshold = s.bOverride_BloomThreshold;
+                m_ppvBaseline.bOverrideBloomKnee = s.bOverride_BloomKnee;
+                m_ppvBaseline.bOverrideBloomIntensity = s.bOverride_BloomIntensity;
+                m_ppvBaseline.bOverrideBloomGaussianIntensity = s.bOverride_BloomGaussianIntensity;
+                m_ppvBaseline.bOverrideBloomRadius = s.bOverride_BloomRadius;
+
+                m_ppvBaseline.splitAmount = s.splitAmount;
+                m_ppvBaseline.splitAngleDeg = s.splitAngleDeg;
+                m_ppvBaseline.splitLineOffset = s.splitLineOffset;
+                m_ppvBaseline.splitFeather = s.splitFeather;
+                m_ppvBaseline.splitFxIntensity = s.splitFxIntensity;
+                m_ppvBaseline.splitFxWidth = s.splitFxWidth;
+                m_ppvBaseline.splitFxSpeed = s.splitFxSpeed;
+                m_ppvBaseline.splitFxTimeSec = s.splitFxTimeSec;
+
+                m_ppvBaseline.exposure = s.exposure;
+                m_ppvBaseline.bloomThreshold = s.bloomThreshold;
+                m_ppvBaseline.bloomKnee = s.bloomKnee;
+                m_ppvBaseline.bloomIntensity = s.bloomIntensity;
+                m_ppvBaseline.bloomGaussianIntensity = s.bloomGaussianIntensity;
+                m_ppvBaseline.bloomRadius = s.bloomRadius;
+            }
+        }
+
+        if (ResolveTargetCamera())
+        {
+            if (auto* cam = world->GetComponent<CameraComponent>(m_cameraEntity))
+            {
+                m_baseFov = cam->GetFov();
+            }
+        }
+    }
+
+    void CameraHalfCutDemo::RefreshFovCurveAsset()
+    {
+        m_fovCurveLoaded = false;
+        m_loadedFovCurvePath = Get_m_fovCurvePath();
+
+        if (!Get_m_useFovCurveAsset())
+            return;
+
+        const std::string& logicalPath = m_loadedFovCurvePath;
+        if (logicalPath.empty())
+            return;
+
+        std::filesystem::path resolved = logicalPath;
+        if (auto* rm = Resources())
+        {
+            resolved = rm->Resolve(logicalPath);
+        }
+
+        UICurveAsset asset{};
+        if (!LoadUICurveAsset(resolved, asset) || asset.keys.empty())
+        {
+            if (!m_fovCurveWarned)
+            {
+                ALICE_LOG_WARN("[CameraHalfCutDemo] Failed to load FOV curve: %s", logicalPath.c_str());
+                m_fovCurveWarned = true;
+            }
+            return;
+        }
+
+        asset.Sort();
+        asset.RecalcAutoTangents();
+        m_fovCurveAsset = std::move(asset);
+        m_fovCurveLoaded = true;
+        m_fovCurveWarned = false;
+    }
+
+    void CameraHalfCutDemo::PrepareOverrides()
+    {
+        World* world = GetWorld();
+        if (!world || !EnsurePostProcessVolume() || m_volumeEntity == InvalidEntityId)
+            return;
+
+        auto* ppv = world->GetComponent<PostProcessVolumeComponent>(m_volumeEntity);
+        if (!ppv)
+            return;
+
+        auto& s = ppv->settings;
+        s.bOverride_SplitAmount = true;
+        s.bOverride_SplitAngleDeg = true;
+        s.bOverride_SplitLineOffset = true;
+        s.bOverride_SplitFeather = true;
+        s.bOverride_SplitFxIntensity = true;
+        s.bOverride_SplitFxWidth = true;
+        s.bOverride_SplitFxSpeed = true;
+        s.bOverride_SplitFxTimeSec = true;
+
+        s.bOverride_Exposure = true;
+        s.bOverride_BloomThreshold = true;
+        s.bOverride_BloomKnee = true;
+        s.bOverride_BloomIntensity = true;
+        s.bOverride_BloomGaussianIntensity = true;
+        s.bOverride_BloomRadius = true;
+    }
+
+    void CameraHalfCutDemo::ApplyEffectState(float timeSec)
+    {
+        const float split = EvaluateSplitAmount(timeSec);
+        const float flash01 = EvaluateFlash01(timeSec);
+        const float fov = EvaluateFov(timeSec);
+
+        ApplyPostProcess(split, flash01, timeSec);
+        ApplyCameraFov(fov);
+
+        const float shakeTriggerTime = std::max(0.0f, Get_m_attackSec());
+        if (!m_shakeTriggered && timeSec >= shakeTriggerTime)
+        {
+            TriggerCameraShake();
+            m_shakeTriggered = true;
+        }
+
+        TrySpawnCutVfx(timeSec);
+        UpdateCutVfxState(timeSec);
+    }
+
+    void CameraHalfCutDemo::ApplyPostProcess(float splitAmount, float flash01, float timeSec)
+    {
+        World* world = GetWorld();
+        if (!world || !EnsurePostProcessVolume() || m_volumeEntity == InvalidEntityId)
+            return;
+
+        auto* ppv = world->GetComponent<PostProcessVolumeComponent>(m_volumeEntity);
+        if (!ppv)
+            return;
+
+        PrepareOverrides();
+
+        auto& s = ppv->settings;
+        s.splitAmount = splitAmount;
+        s.splitAngleDeg = Get_m_angleDeg();
+        s.splitLineOffset = Get_m_lineOffset();
+        s.splitFeather = std::max(0.0001f, Get_m_feather());
+        s.splitFxWidth = std::max(0.0001f, Get_m_splitFxWidth());
+        s.splitFxSpeed = std::max(0.0f, Get_m_splitFxSpeed());
+        s.splitFxTimeSec = std::max(0.0f, timeSec) * std::max(0.0f, Get_m_splitFxTimeScale());
+
+        const float peakAbs = std::max(std::abs(Get_m_peakAmount()), 1e-6f);
+        const float split01 = Saturate(std::abs(splitAmount) / peakAbs);
+        const float fx01 = std::max(split01, flash01);
+        s.splitFxIntensity = Get_m_splitFxEnabled()
+            ? std::max(0.0f, Get_m_splitFxIntensity()) * fx01
+            : 0.0f;
+
+        const float baseExposure = m_ppvBaseline.valid ? m_ppvBaseline.exposure : 0.0f;
+        const float baseBloomThreshold = m_ppvBaseline.valid ? m_ppvBaseline.bloomThreshold : 1.0f;
+        const float baseBloomKnee = m_ppvBaseline.valid ? m_ppvBaseline.bloomKnee : 0.5f;
+        const float baseBloomIntensity = m_ppvBaseline.valid ? m_ppvBaseline.bloomIntensity : 0.0f;
+        const float baseBloomGaussianIntensity = m_ppvBaseline.valid ? m_ppvBaseline.bloomGaussianIntensity : 1.0f;
+        const float baseBloomRadius = m_ppvBaseline.valid ? m_ppvBaseline.bloomRadius : 1.0f;
+
+        s.exposure = Lerp(baseExposure, Get_m_peakExposure(), flash01);
+        s.bloomThreshold = Lerp(baseBloomThreshold, Get_m_peakBloomThreshold(), flash01);
+        s.bloomKnee = Lerp(baseBloomKnee, Get_m_peakBloomKnee(), flash01);
+        s.bloomIntensity = Lerp(baseBloomIntensity, Get_m_peakBloomIntensity(), flash01);
+        s.bloomGaussianIntensity = Lerp(baseBloomGaussianIntensity, Get_m_peakBloomGaussianIntensity(), flash01);
+        s.bloomRadius = Lerp(baseBloomRadius, Get_m_peakBloomRadius(), flash01);
+    }
+
+    void CameraHalfCutDemo::ApplyCameraFov(float fovDeg)
+    {
+        World* world = GetWorld();
+        if (!world)
+            return;
+
+        if (!ResolveTargetCamera() || m_cameraEntity == InvalidEntityId)
+            return;
+
+        auto* cam = world->GetComponent<CameraComponent>(m_cameraEntity);
+        if (!cam)
+            return;
+
+        cam->SetFov(std::clamp(fovDeg, 1.0f, 170.0f));
+    }
+
+    void CameraHalfCutDemo::TriggerCameraShake()
+    {
+        World* world = GetWorld();
+        if (!world || !ResolveTargetCamera() || m_cameraEntity == InvalidEntityId)
+            return;
+
+        auto* shake = world->GetComponent<CameraShakeComponent>(m_cameraEntity);
+        if (!shake)
+        {
+            shake = &world->AddComponent<CameraShakeComponent>(m_cameraEntity);
+        }
+
+        const float amp = std::max(0.0f, Get_m_shakeAmplitude());
+        const float freq = std::max(0.0f, Get_m_shakeFrequency());
+        const float dur = std::max(0.0f, Get_m_shakeDuration());
+        const float decay = std::max(0.0f, Get_m_shakeDecay());
+
+        if (amp <= 0.0f || dur <= 0.0f)
+            return;
+
+        const bool active = shake->IsActive();
+        shake->enabled = true;
+        shake->frequency = freq;
+        shake->decay = decay;
+
+        if (!active)
+        {
+            shake->amplitude = amp;
+            shake->duration = dur;
+            shake->elapsed = 0.0f;
+            shake->prevOffset = {};
+            return;
+        }
+
+        shake->amplitude += amp;
+        const float endTime = shake->duration;
+        const float newEnd = shake->elapsed + dur;
+        shake->duration = std::max(endTime, newEnd);
+    }
+
+    void CameraHalfCutDemo::TrySpawnCutVfx(float timeSec)
+    {
+        if (!Get_m_spawnCutVfx() || m_vfxTriggered)
+            return;
+
+        if (timeSec < std::max(0.0f, Get_m_cutVfxTriggerSec()))
+            return;
+
+        m_activeCutVfx = SpawnCutVfx();
+        m_vfxTriggered = (m_activeCutVfx != InvalidEntityId);
+    }
+
+    void CameraHalfCutDemo::UpdateCutVfxState(float timeSec)
+    {
+        World* world = GetWorld();
+        if (!world || m_activeCutVfx == InvalidEntityId)
+            return;
+
+        if (!world->GetComponent<TransformComponent>(m_activeCutVfx))
+        {
+            m_activeCutVfx = InvalidEntityId;
+            return;
+        }
+
+        const float total = std::max(0.0f, GetTotalDuration());
+        if (total <= 0.0f)
+            return;
+
+        const float fadeSec = std::clamp(Get_m_cutVfxFadeOutSec(), 0.0f, total);
+        const float fadeStart = std::max(0.0f, total - fadeSec);
+
+        float fade01 = 1.0f;
+        if (fadeSec > 0.0f && timeSec >= fadeStart)
+        {
+            const float t = (timeSec - fadeStart) / fadeSec;
+            fade01 = 1.0f - EaseInCubic(t);
+        }
+        fade01 = Saturate(fade01);
+
+        const bool forceOneShot = Get_m_cutVfxForceOneShot();
+        const bool loop = !forceOneShot;
+        const bool emit = forceOneShot ? true : ((fade01 > 0.02f) && (timeSec < total));
+        ApplyCutVfxRuntimeRecursive(m_activeCutVfx, fade01, emit, loop);
+    }
+
+    EntityId CameraHalfCutDemo::SpawnCutVfx()
+    {
+        const std::string& prefabPath = Get_m_cutVfxPrefabPath();
+        if (prefabPath.empty())
+            return InvalidEntityId;
+
+        World* world = GetWorld();
+        if (!world)
+            return InvalidEntityId;
+
+        Prefab::SetDefaultWorld(world);
+        const EntityId id = Prefab::InstantiateFromFileAuto(prefabPath);
+        if (id == InvalidEntityId)
+        {
+            ALICE_LOG_WARN("[CameraHalfCutDemo] Cut VFX instantiate failed: %s", prefabPath.c_str());
+            return InvalidEntityId;
+        }
+
+        world->SetParent(id, InvalidEntityId, false);
+
+        if (auto* tr = world->GetComponent<TransformComponent>(id))
+        {
+            DirectX::XMFLOAT3 spawnPos = {};
+            DirectX::XMFLOAT3 spawnRot = {};
+            bool hasSpawnPos = false;
+
+            if (ResolveTargetCamera() && m_cameraEntity != InvalidEntityId)
+            {
+                if (auto* camTr = world->GetComponent<TransformComponent>(m_cameraEntity))
+                {
+                    using namespace DirectX;
+                    const XMVECTOR camPos = XMLoadFloat3(&camTr->position);
+                    const XMMATRIX rotM = XMMatrixRotationRollPitchYaw(camTr->rotation.x, camTr->rotation.y, camTr->rotation.z);
+
+                    const XMVECTOR right = XMVector3TransformNormal(XMVectorSet(1.0f, 0.0f, 0.0f, 0.0f), rotM);
+                    const XMVECTOR up = XMVector3TransformNormal(XMVectorSet(0.0f, 1.0f, 0.0f, 0.0f), rotM);
+                    const XMVECTOR fwd = XMVector3TransformNormal(XMVectorSet(0.0f, 0.0f, 1.0f, 0.0f), rotM);
+
+                    const DirectX::XMFLOAT3 local = Get_m_cutVfxLocalOffset();
+                    const float forwardDist = std::max(0.0f, Get_m_cutVfxForwardDistance()) + local.z;
+                    const XMVECTOR p = camPos
+                        + right * local.x
+                        + up * local.y
+                        + fwd * forwardDist;
+
+                    XMStoreFloat3(&spawnPos, p);
+                    spawnRot = camTr->rotation;
+                    hasSpawnPos = true;
+                }
+            }
+
+            if (Get_m_cutVfxUseAnchorMidpoint())
+            {
+                const std::string& aName = Get_m_cutVfxAnchorAName();
+                const std::string& bName = Get_m_cutVfxAnchorBName();
+                if (!aName.empty() && !bName.empty())
+                {
+                    GameObject aGo = world->FindGameObject(aName);
+                    GameObject bGo = world->FindGameObject(bName);
+                    if (aGo.IsValid() && bGo.IsValid())
+                    {
+                        const auto* aTr = world->GetComponent<TransformComponent>(aGo.id());
+                        const auto* bTr = world->GetComponent<TransformComponent>(bGo.id());
+                        if (aTr && bTr)
+                        {
+                            const auto off = Get_m_cutVfxMidpointOffset();
+                            spawnPos.x = (aTr->position.x + bTr->position.x) * 0.5f + off.x;
+                            spawnPos.y = (aTr->position.y + bTr->position.y) * 0.5f + off.y;
+                            spawnPos.z = (aTr->position.z + bTr->position.z) * 0.5f + off.z;
+                            hasSpawnPos = true;
+                        }
+                    }
+                }
+            }
+
+            if (!hasSpawnPos)
+            {
+                spawnPos = Get_m_cutVfxLocalOffset();
+            }
+
+            const DirectX::XMFLOAT3 rotDeg = Get_m_cutVfxEulerOffsetDeg();
+            spawnRot.x += DirectX::XMConvertToRadians(rotDeg.x);
+            spawnRot.y += DirectX::XMConvertToRadians(rotDeg.y);
+            spawnRot.z += DirectX::XMConvertToRadians(rotDeg.z);
+
+            tr->position = spawnPos;
+            tr->rotation = spawnRot;
+            tr->scale = Get_m_cutVfxScale();
+            world->MarkTransformDirty(id);
+        }
+
+        ConfigureCutVfxRecursive(id);
+
+        return id;
+    }
+
+    void CameraHalfCutDemo::ConfigureCutVfxRecursive(EntityId id)
+    {
+        World* world = GetWorld();
+        if (!world || id == InvalidEntityId)
+            return;
+
+        if (auto* vfx = world->GetComponent<UnityVfxComponent>(id))
+        {
+            vfx->enabled = true;
+            vfx->overrideLoop = true;
+            vfx->loop = !Get_m_cutVfxForceOneShot();
+            vfx->emitNewParticles = true;
+            vfx->spawnRateScale = std::max(0.0f, Get_m_cutVfxBaseSpawnRate());
+            vfx->alphaScale = std::max(0.0f, Get_m_cutVfxBaseAlpha());
+            vfx->intensityScale = std::max(0.0f, Get_m_cutVfxBaseIntensity());
+            vfx->playId += 1;
+        }
+
+        if (auto* ce = world->GetComponent<ComputeEffectComponent>(id))
+        {
+            ce->enabled = true;
+        }
+
+        const auto children = world->GetChildren(id);
+        for (EntityId child : children)
+        {
+            ConfigureCutVfxRecursive(child);
+        }
+    }
+
+    void CameraHalfCutDemo::ApplyCutVfxRuntimeRecursive(EntityId id, float fade01, bool emitNewParticles, bool loop)
+    {
+        World* world = GetWorld();
+        if (!world || id == InvalidEntityId)
+            return;
+
+        if (auto* vfx = world->GetComponent<UnityVfxComponent>(id))
+        {
+            const float fade = Saturate(fade01);
+            vfx->enabled = true;
+            vfx->overrideLoop = true;
+            vfx->loop = loop;
+            vfx->emitNewParticles = emitNewParticles;
+            vfx->spawnRateScale = std::max(0.0f, Get_m_cutVfxBaseSpawnRate()) * fade;
+            vfx->alphaScale = std::max(0.0f, Get_m_cutVfxBaseAlpha()) * fade;
+            vfx->intensityScale = std::max(0.0f, Get_m_cutVfxBaseIntensity()) * fade;
+        }
+
+        const auto children = world->GetChildren(id);
+        for (EntityId child : children)
+        {
+            ApplyCutVfxRuntimeRecursive(child, fade01, emitNewParticles, loop);
+        }
+    }
+
+    void CameraHalfCutDemo::ResetAll()
+    {
+        World* world = GetWorld();
+        if (!world)
+            return;
+
+        if (m_volumeEntity != InvalidEntityId)
+        {
+            if (auto* ppv = world->GetComponent<PostProcessVolumeComponent>(m_volumeEntity))
+            {
+                auto& s = ppv->settings;
+                if (m_ppvBaseline.valid)
+                {
+                    s.bOverride_SplitAmount = m_ppvBaseline.bOverrideSplitAmount;
+                    s.bOverride_SplitAngleDeg = m_ppvBaseline.bOverrideSplitAngleDeg;
+                    s.bOverride_SplitLineOffset = m_ppvBaseline.bOverrideSplitLineOffset;
+                    s.bOverride_SplitFeather = m_ppvBaseline.bOverrideSplitFeather;
+                    s.bOverride_SplitFxIntensity = m_ppvBaseline.bOverrideSplitFxIntensity;
+                    s.bOverride_SplitFxWidth = m_ppvBaseline.bOverrideSplitFxWidth;
+                    s.bOverride_SplitFxSpeed = m_ppvBaseline.bOverrideSplitFxSpeed;
+                    s.bOverride_SplitFxTimeSec = m_ppvBaseline.bOverrideSplitFxTimeSec;
+                    s.bOverride_Exposure = m_ppvBaseline.bOverrideExposure;
+                    s.bOverride_BloomThreshold = m_ppvBaseline.bOverrideBloomThreshold;
+                    s.bOverride_BloomKnee = m_ppvBaseline.bOverrideBloomKnee;
+                    s.bOverride_BloomIntensity = m_ppvBaseline.bOverrideBloomIntensity;
+                    s.bOverride_BloomGaussianIntensity = m_ppvBaseline.bOverrideBloomGaussianIntensity;
+                    s.bOverride_BloomRadius = m_ppvBaseline.bOverrideBloomRadius;
+
+                    s.splitAmount = m_ppvBaseline.splitAmount;
+                    s.splitAngleDeg = m_ppvBaseline.splitAngleDeg;
+                    s.splitLineOffset = m_ppvBaseline.splitLineOffset;
+                    s.splitFeather = m_ppvBaseline.splitFeather;
+                    s.splitFxIntensity = m_ppvBaseline.splitFxIntensity;
+                    s.splitFxWidth = m_ppvBaseline.splitFxWidth;
+                    s.splitFxSpeed = m_ppvBaseline.splitFxSpeed;
+                    s.splitFxTimeSec = m_ppvBaseline.splitFxTimeSec;
+                    s.exposure = m_ppvBaseline.exposure;
+                    s.bloomThreshold = m_ppvBaseline.bloomThreshold;
+                    s.bloomKnee = m_ppvBaseline.bloomKnee;
+                    s.bloomIntensity = m_ppvBaseline.bloomIntensity;
+                    s.bloomGaussianIntensity = m_ppvBaseline.bloomGaussianIntensity;
+                    s.bloomRadius = m_ppvBaseline.bloomRadius;
+                }
+                else
+                {
+                    s.bOverride_SplitAmount = true;
+                    s.splitAmount = 0.0f;
+                    s.bOverride_SplitFxIntensity = true;
+                    s.bOverride_SplitFxWidth = true;
+                    s.bOverride_SplitFxSpeed = true;
+                    s.bOverride_SplitFxTimeSec = true;
+                    s.splitFxIntensity = 0.0f;
+                    s.splitFxWidth = 0.01f;
+                    s.splitFxSpeed = 30.0f;
+                    s.splitFxTimeSec = 0.0f;
+                }
+            }
+        }
+
+        if (ResolveTargetCamera() && m_cameraEntity != InvalidEntityId)
+        {
+            if (auto* cam = world->GetComponent<CameraComponent>(m_cameraEntity))
+            {
+                cam->SetFov(m_baseFov);
+            }
+        }
+
+        if (m_activeCutVfx != InvalidEntityId && world->GetComponent<TransformComponent>(m_activeCutVfx))
+        {
+            ApplyCutVfxRuntimeRecursive(m_activeCutVfx, 0.0f, false, false);
+            const float despawn = std::max(0.0f, Get_m_cutVfxDespawnDelaySec());
+            if (despawn > 0.0f)
+                world->ScheduleDelayedDestruction(m_activeCutVfx, despawn);
+            else
+                world->DestroyEntity(m_activeCutVfx);
+        }
+
+        m_shakeTriggered = false;
+        m_vfxTriggered = false;
+        m_elapsedSec = 0.0f;
+    }
+
+    float CameraHalfCutDemo::GetTotalDuration() const
+    {
+        return
+            std::max(0.0f, Get_m_attackSec()) +
+            std::max(0.0f, Get_m_holdSec()) +
+            std::max(0.0f, Get_m_releaseSec());
+    }
+
+    float CameraHalfCutDemo::EvaluateSplitAmount(float timeSec) const
+    {
+        const float peak = Get_m_peakAmount();
+        const float attack = std::max(0.0f, Get_m_attackSec());
+        const float hold = std::max(0.0f, Get_m_holdSec());
+        const float release = std::max(0.0f, Get_m_releaseSec());
+
+        float t = std::max(0.0f, timeSec);
+        if (attack > 0.0f && t < attack)
+            return peak * EaseOutCubic(t / attack);
+
+        t -= attack;
+        if (t < hold)
+            return peak;
+
+        t -= hold;
+        if (release <= 0.0f)
+            return 0.0f;
+
+        return peak * (1.0f - EaseInCubic(t / release));
+    }
+
+    float CameraHalfCutDemo::EvaluateFlash01(float timeSec) const
+    {
+        const float attack = std::max(0.0f, Get_m_attackSec());
+        const float hold = std::max(0.0f, Get_m_holdSec());
+        const float release = std::max(0.0f, Get_m_releaseSec());
+
+        float t = std::max(0.0f, timeSec);
+        if (t < attack)
+            return 0.0f;
+
+        t -= attack;
+        if (t < hold)
+            return 1.0f;
+
+        t -= hold;
+        if (release <= 0.0f)
+            return 0.0f;
+
+        return 1.0f - EaseInCubic(t / release);
+    }
+
+    float CameraHalfCutDemo::EvaluateFovCurveValue(float timeSec) const
+    {
+        if (!Get_m_useFovCurveAsset() || !m_fovCurveLoaded || m_fovCurveAsset.keys.empty())
+            return -1.0f;
+
+        const float effectTotal = std::max(GetTotalDuration(), 1e-6f);
+        const float normalized = Saturate(std::max(0.0f, timeSec) / effectTotal);
+        const float scaledNormalized = Saturate(normalized * std::max(0.0f, Get_m_fovCurveTimeScale()));
+
+        const float curveDuration = m_fovCurveAsset.GetDuration();
+        const float curveTime = (curveDuration > 0.0f) ? (scaledNormalized * curveDuration) : 0.0f;
+
+        float v = m_fovCurveAsset.Evaluate(curveTime);
+        v = v * Get_m_fovCurveValueScale() + Get_m_fovCurveValueBias();
+        if (Get_m_fovCurveClamp01())
+            v = Saturate(v);
+
+        return v;
+    }
+
+    float CameraHalfCutDemo::EvaluateFov(float timeSec) const
+    {
+        const float baseFov = m_baseFov;
+        const float zoomFov = std::clamp(Get_m_zoomFov(), 1.0f, 170.0f);
+
+        const float curveV = EvaluateFovCurveValue(timeSec);
+        if (curveV >= 0.0f)
+        {
+            return std::clamp(LerpUnclamped(baseFov, zoomFov, curveV), 1.0f, 170.0f);
+        }
+
+        const float attack = std::max(0.0f, Get_m_attackSec());
+        const float hold = std::max(0.0f, Get_m_holdSec());
+        const float release = std::max(0.0f, Get_m_releaseSec());
+
+        float t = std::max(0.0f, timeSec);
+        if (attack > 0.0f && t < attack)
+            return Lerp(baseFov, zoomFov, EaseOutCubic(t / attack));
+
+        t -= attack;
+        if (t < hold)
+            return zoomFov;
+
+        t -= hold;
+        if (release <= 0.0f)
+            return baseFov;
+
+        return Lerp(zoomFov, baseFov, EaseInCubic(t / release));
+    }
+}

--- a/Assets/Scripts/Camera/CameraHalfCutDemo.h
+++ b/Assets/Scripts/Camera/CameraHalfCutDemo.h
@@ -1,0 +1,154 @@
+#pragma once
+
+#include <string>
+#include <DirectXMath.h>
+
+#include "Runtime/Scripting/IScript.h"
+#include "Runtime/Scripting/ScriptReflection.h"
+#include "Runtime/ECS/Entity.h"
+#include "Runtime/Input/InputTypes.h"
+#include "Runtime/UI/UICurveAsset.h"
+
+namespace Alice
+{
+    class CameraHalfCutDemo : public IScript
+    {
+        ALICE_BODY(CameraHalfCutDemo);
+
+    public:
+        const char* GetName() const override { return "CameraHalfCutDemo"; }
+
+        void Start() override;
+        void Update(float deltaTime) override;
+        void OnDisable() override;
+        void OnDestroy() override;
+
+    private:
+        bool EnsurePostProcessVolume();
+        bool ResolveTargetCamera();
+        void CaptureBaseline();
+        void RefreshFovCurveAsset();
+        void PrepareOverrides();
+        void ApplyEffectState(float timeSec);
+        void ApplyPostProcess(float splitAmount, float flash01, float timeSec);
+        void ApplyCameraFov(float fovDeg);
+        void TriggerCameraShake();
+        void TrySpawnCutVfx(float timeSec);
+        void UpdateCutVfxState(float timeSec);
+        EntityId SpawnCutVfx();
+        void ConfigureCutVfxRecursive(EntityId id);
+        void ApplyCutVfxRuntimeRecursive(EntityId id, float fade01, bool emitNewParticles, bool loop);
+        void ResetAll();
+        float GetTotalDuration() const;
+        float EvaluateSplitAmount(float timeSec) const;
+        float EvaluateFlash01(float timeSec) const;
+        float EvaluateFovCurveValue(float timeSec) const;
+        float EvaluateFov(float timeSec) const;
+
+    private:
+        struct PpvBaseline
+        {
+            bool valid{ false };
+
+            bool bOverrideSplitAmount{ false };
+            bool bOverrideSplitAngleDeg{ false };
+            bool bOverrideSplitLineOffset{ false };
+            bool bOverrideSplitFeather{ false };
+
+            bool bOverrideExposure{ false };
+            bool bOverrideBloomThreshold{ false };
+            bool bOverrideBloomKnee{ false };
+            bool bOverrideBloomIntensity{ false };
+            bool bOverrideBloomGaussianIntensity{ false };
+            bool bOverrideBloomRadius{ false };
+
+            float splitAmount{ 0.0f };
+            float splitAngleDeg{ 0.0f };
+            float splitLineOffset{ 0.0f };
+            float splitFeather{ 0.001f };
+            bool bOverrideSplitFxIntensity{ false };
+            bool bOverrideSplitFxWidth{ false };
+            bool bOverrideSplitFxSpeed{ false };
+            bool bOverrideSplitFxTimeSec{ false };
+            float splitFxIntensity{ 0.0f };
+            float splitFxWidth{ 0.01f };
+            float splitFxSpeed{ 30.0f };
+            float splitFxTimeSec{ 0.0f };
+
+            float exposure{ 0.0f };
+            float bloomThreshold{ 1.0f };
+            float bloomKnee{ 0.5f };
+            float bloomIntensity{ 0.0f };
+            float bloomGaussianIntensity{ 1.0f };
+            float bloomRadius{ 1.0f };
+        };
+
+    private:
+        ALICE_PROPERTY(int, m_triggerKey, static_cast<int>(KeyCode::Alpha1));
+        ALICE_PROPERTY(std::string, m_cameraName, "MainCamera");
+        ALICE_PROPERTY(std::string, m_postProcessVolumeName, "CameraHalfCutVolume");
+        ALICE_PROPERTY(bool, m_autoCreateVolume, true);
+        ALICE_PROPERTY(float, m_peakAmount, 0.08f);
+        ALICE_PROPERTY(float, m_angleDeg, 12.0f);
+        ALICE_PROPERTY(float, m_lineOffset, 0.0f);
+        ALICE_PROPERTY(float, m_feather, 0.002f);
+        ALICE_PROPERTY(float, m_attackSec, 0.08f);
+        ALICE_PROPERTY(float, m_holdSec, 0.05f);
+        ALICE_PROPERTY(float, m_releaseSec, 0.22f);
+        ALICE_PROPERTY(float, m_zoomFov, 28.0f);
+        ALICE_PROPERTY(bool, m_useFovCurveAsset, true);
+        ALICE_PROPERTY(std::string, m_fovCurvePath, "Assets/Curves/UI/FadeInOut.uicurve");
+        ALICE_PROPERTY(float, m_fovCurveTimeScale, 1.0f);
+        ALICE_PROPERTY(float, m_fovCurveValueScale, 1.0f);
+        ALICE_PROPERTY(float, m_fovCurveValueBias, 0.0f);
+        ALICE_PROPERTY(bool, m_fovCurveClamp01, false);
+        ALICE_PROPERTY(float, m_peakExposure, 3.5f);
+        ALICE_PROPERTY(float, m_peakBloomIntensity, 2.6f);
+        ALICE_PROPERTY(float, m_peakBloomGaussianIntensity, 2.2f);
+        ALICE_PROPERTY(float, m_peakBloomRadius, 1.8f);
+        ALICE_PROPERTY(float, m_peakBloomThreshold, 0.35f);
+        ALICE_PROPERTY(float, m_peakBloomKnee, 0.65f);
+        ALICE_PROPERTY(bool, m_splitFxEnabled, true);
+        ALICE_PROPERTY(float, m_splitFxIntensity, 1.45f);
+        ALICE_PROPERTY(float, m_splitFxWidth, 0.01f);
+        ALICE_PROPERTY(float, m_splitFxSpeed, 36.0f);
+        ALICE_PROPERTY(float, m_splitFxTimeScale, 1.0f);
+        ALICE_PROPERTY(float, m_shakeAmplitude, 0.15f);
+        ALICE_PROPERTY(float, m_shakeFrequency, 30.0f);
+        ALICE_PROPERTY(float, m_shakeDuration, 0.23f);
+        ALICE_PROPERTY(float, m_shakeDecay, 2.2f);
+        ALICE_PROPERTY(int, m_volumePriority, 500);
+        ALICE_PROPERTY(bool, m_spawnCutVfx, true);
+        ALICE_PROPERTY(std::string, m_cutVfxPrefabPath, "Assets/Prefabs/(04)Charging.prefab");
+        ALICE_PROPERTY(float, m_cutVfxTriggerSec, 0.08f);
+        ALICE_PROPERTY(bool, m_cutVfxUseAnchorMidpoint, true);
+        ALICE_PROPERTY(std::string, m_cutVfxAnchorAName, "LeftCube");
+        ALICE_PROPERTY(std::string, m_cutVfxAnchorBName, "RightCube");
+        ALICE_PROPERTY(DirectX::XMFLOAT3, m_cutVfxMidpointOffset, DirectX::XMFLOAT3(0.0f, 0.0f, 0.0f));
+        ALICE_PROPERTY(float, m_cutVfxForwardDistance, 9.0f);
+        ALICE_PROPERTY(DirectX::XMFLOAT3, m_cutVfxLocalOffset, DirectX::XMFLOAT3(0.0f, -0.35f, 0.0f));
+        ALICE_PROPERTY(DirectX::XMFLOAT3, m_cutVfxEulerOffsetDeg, DirectX::XMFLOAT3(0.0f, 0.0f, 0.0f));
+        ALICE_PROPERTY(DirectX::XMFLOAT3, m_cutVfxScale, DirectX::XMFLOAT3(0.75f, 0.75f, 0.75f));
+        ALICE_PROPERTY(float, m_cutVfxFadeOutSec, 0.22f);
+        ALICE_PROPERTY(float, m_cutVfxDespawnDelaySec, 0.8f);
+        ALICE_PROPERTY(float, m_cutVfxBaseSpawnRate, 1.0f);
+        ALICE_PROPERTY(float, m_cutVfxBaseAlpha, 1.0f);
+        ALICE_PROPERTY(float, m_cutVfxBaseIntensity, 1.0f);
+        ALICE_PROPERTY(bool, m_cutVfxForceOneShot, false);
+
+        PpvBaseline m_ppvBaseline{};
+        EntityId m_volumeEntity{ InvalidEntityId };
+        EntityId m_cameraEntity{ InvalidEntityId };
+        EntityId m_activeCutVfx{ InvalidEntityId };
+        bool m_playing{ false };
+        bool m_shakeTriggered{ false };
+        bool m_vfxTriggered{ false };
+        float m_elapsedSec{ 0.0f };
+        float m_baseFov{ 45.0f };
+        UICurveAsset m_fovCurveAsset{};
+        bool m_fovCurveLoaded{ false };
+        bool m_fovCurveWarned{ false };
+        std::string m_loadedFovCurvePath{};
+        bool m_warnedMissingVolume{ false };
+    };
+}

--- a/Engine/src/Runtime/ECS/ComponentRegistry.cpp
+++ b/Engine/src/Runtime/ECS/ComponentRegistry.cpp
@@ -733,7 +733,24 @@ namespace Alice
             .property("bOverride_BloomRadius", &PostProcessSettings::bOverride_BloomRadius)
             .property("bloomRadius", &PostProcessSettings::bloomRadius)
             .property("bOverride_BloomDownsample", &PostProcessSettings::bOverride_BloomDownsample)
-            .property("bloomDownsample", &PostProcessSettings::bloomDownsample);
+            .property("bloomDownsample", &PostProcessSettings::bloomDownsample)
+            // HalfCut screen split
+            .property("bOverride_SplitAmount", &PostProcessSettings::bOverride_SplitAmount)
+            .property("splitAmount", &PostProcessSettings::splitAmount)
+            .property("bOverride_SplitAngleDeg", &PostProcessSettings::bOverride_SplitAngleDeg)
+            .property("splitAngleDeg", &PostProcessSettings::splitAngleDeg)
+            .property("bOverride_SplitLineOffset", &PostProcessSettings::bOverride_SplitLineOffset)
+            .property("splitLineOffset", &PostProcessSettings::splitLineOffset)
+            .property("bOverride_SplitFeather", &PostProcessSettings::bOverride_SplitFeather)
+            .property("splitFeather", &PostProcessSettings::splitFeather)
+            .property("bOverride_SplitFxIntensity", &PostProcessSettings::bOverride_SplitFxIntensity)
+            .property("splitFxIntensity", &PostProcessSettings::splitFxIntensity)
+            .property("bOverride_SplitFxWidth", &PostProcessSettings::bOverride_SplitFxWidth)
+            .property("splitFxWidth", &PostProcessSettings::splitFxWidth)
+            .property("bOverride_SplitFxSpeed", &PostProcessSettings::bOverride_SplitFxSpeed)
+            .property("splitFxSpeed", &PostProcessSettings::splitFxSpeed)
+            .property("bOverride_SplitFxTimeSec", &PostProcessSettings::bOverride_SplitFxTimeSec)
+            .property("splitFxTimeSec", &PostProcessSettings::splitFxTimeSec);
 
         // === ComputeEffectComponent ��� ===
         rttr::registration::class_<ComputeEffectComponent>("ComputeEffectComponent")

--- a/Engine/src/Runtime/Rendering/DeferredRenderSystem.cpp
+++ b/Engine/src/Runtime/Rendering/DeferredRenderSystem.cpp
@@ -1431,7 +1431,7 @@ namespace Alice
             return false;
 
         // PostProcess CB
-        cbDesc.ByteWidth = sizeof(PostProcessCB) * 4; // exposure, maxHDRNits, padding
+        cbDesc.ByteWidth = static_cast<UINT>((sizeof(PostProcessCB) + 15) / 16 * 16);
         if (FAILED(m_device->CreateBuffer(&cbDesc, nullptr, m_cbPostProcess.ReleaseAndGetAddressOf())))
             return false;
 
@@ -2626,6 +2626,14 @@ namespace Alice
                     m_postProcessParams.colorGradingGain.y,
                     m_postProcessParams.colorGradingGain.z
                 );
+                defaultSettings.splitAmount = m_postProcessParams.splitAmount;
+                defaultSettings.splitAngleDeg = m_postProcessParams.splitAngleDeg;
+                defaultSettings.splitLineOffset = m_postProcessParams.splitLineOffset;
+                defaultSettings.splitFeather = m_postProcessParams.splitFeather;
+                defaultSettings.splitFxIntensity = m_postProcessParams.splitFxIntensity;
+                defaultSettings.splitFxWidth = m_postProcessParams.splitFxWidth;
+                defaultSettings.splitFxSpeed = m_postProcessParams.splitFxSpeed;
+                defaultSettings.splitFxTimeSec = m_postProcessParams.splitFxTimeSec;
                 // Bloom 기본 설정
                 defaultSettings.bloomThreshold = m_bloomSettings.threshold;
                 defaultSettings.bloomKnee = m_bloomSettings.knee;
@@ -2675,6 +2683,14 @@ namespace Alice
                 finalSettings.gain.z,
                 1.0f
             );
+            m_postProcessParams.splitAmount = finalSettings.splitAmount;
+            m_postProcessParams.splitAngleDeg = finalSettings.splitAngleDeg;
+            m_postProcessParams.splitLineOffset = finalSettings.splitLineOffset;
+            m_postProcessParams.splitFeather = finalSettings.splitFeather;
+            m_postProcessParams.splitFxIntensity = finalSettings.splitFxIntensity;
+            m_postProcessParams.splitFxWidth = finalSettings.splitFxWidth;
+            m_postProcessParams.splitFxSpeed = finalSettings.splitFxSpeed;
+            m_postProcessParams.splitFxTimeSec = finalSettings.splitFxTimeSec;
             // Bloom 설정 적용
             m_bloomSettings.threshold = finalSettings.bloomThreshold;
             m_bloomSettings.knee = finalSettings.bloomKnee;
@@ -2855,6 +2871,14 @@ namespace Alice
                     m_postProcessParams.colorGradingGain.y,
                     m_postProcessParams.colorGradingGain.z
                 );
+                defaultSettings.splitAmount = m_postProcessParams.splitAmount;
+                defaultSettings.splitAngleDeg = m_postProcessParams.splitAngleDeg;
+                defaultSettings.splitLineOffset = m_postProcessParams.splitLineOffset;
+                defaultSettings.splitFeather = m_postProcessParams.splitFeather;
+                defaultSettings.splitFxIntensity = m_postProcessParams.splitFxIntensity;
+                defaultSettings.splitFxWidth = m_postProcessParams.splitFxWidth;
+                defaultSettings.splitFxSpeed = m_postProcessParams.splitFxSpeed;
+                defaultSettings.splitFxTimeSec = m_postProcessParams.splitFxTimeSec;
             }
 
             const std::string referenceName = ResolvePPVReferenceName(world);
@@ -2895,6 +2919,14 @@ namespace Alice
                 finalSettings.gain.z,
                 1.0f
             );
+            m_postProcessParams.splitAmount = finalSettings.splitAmount;
+            m_postProcessParams.splitAngleDeg = finalSettings.splitAngleDeg;
+            m_postProcessParams.splitLineOffset = finalSettings.splitLineOffset;
+            m_postProcessParams.splitFeather = finalSettings.splitFeather;
+            m_postProcessParams.splitFxIntensity = finalSettings.splitFxIntensity;
+            m_postProcessParams.splitFxWidth = finalSettings.splitFxWidth;
+            m_postProcessParams.splitFxSpeed = finalSettings.splitFxSpeed;
+            m_postProcessParams.splitFxTimeSec = finalSettings.splitFxTimeSec;
         }
 
         if (m_viewportRTV)
@@ -4799,6 +4831,14 @@ namespace Alice
 			m_postProcessParams.colorGradingGain.y,
 			m_postProcessParams.colorGradingGain.z
 		);
+		defaultSettings.splitAmount = m_postProcessParams.splitAmount;
+		defaultSettings.splitAngleDeg = m_postProcessParams.splitAngleDeg;
+		defaultSettings.splitLineOffset = m_postProcessParams.splitLineOffset;
+		defaultSettings.splitFeather = m_postProcessParams.splitFeather;
+		defaultSettings.splitFxIntensity = m_postProcessParams.splitFxIntensity;
+		defaultSettings.splitFxWidth = m_postProcessParams.splitFxWidth;
+		defaultSettings.splitFxSpeed = m_postProcessParams.splitFxSpeed;
+		defaultSettings.splitFxTimeSec = m_postProcessParams.splitFxTimeSec;
 		// Bloom 기본 설정
 		defaultSettings.bloomThreshold = m_bloomSettings.threshold;
 		defaultSettings.bloomKnee = m_bloomSettings.knee;
@@ -4848,6 +4888,14 @@ namespace Alice
 			finalSettings.gain.z,
 			1.0f
 		);
+		m_postProcessParams.splitAmount = finalSettings.splitAmount;
+		m_postProcessParams.splitAngleDeg = finalSettings.splitAngleDeg;
+		m_postProcessParams.splitLineOffset = finalSettings.splitLineOffset;
+		m_postProcessParams.splitFeather = finalSettings.splitFeather;
+		m_postProcessParams.splitFxIntensity = finalSettings.splitFxIntensity;
+		m_postProcessParams.splitFxWidth = finalSettings.splitFxWidth;
+		m_postProcessParams.splitFxSpeed = finalSettings.splitFxSpeed;
+		m_postProcessParams.splitFxTimeSec = finalSettings.splitFxTimeSec;
 		// Bloom 설정 적용
 		m_bloomSettings.threshold = finalSettings.bloomThreshold;
 		m_bloomSettings.knee = finalSettings.bloomKnee;
@@ -5019,6 +5067,18 @@ namespace Alice
         cbData.colorGradingContrast = m_postProcessParams.colorGradingContrast;
         cbData.colorGradingGamma = m_postProcessParams.colorGradingGamma;
         cbData.colorGradingGain = m_postProcessParams.colorGradingGain;
+        cbData.splitParams = DirectX::XMFLOAT4(
+            m_postProcessParams.splitAmount,
+            m_postProcessParams.splitAngleDeg,
+            m_postProcessParams.splitLineOffset,
+            m_postProcessParams.splitFeather
+        );
+        cbData.splitFxParams = DirectX::XMFLOAT4(
+            m_postProcessParams.splitFxIntensity,
+            m_postProcessParams.splitFxWidth,
+            m_postProcessParams.splitFxSpeed,
+            m_postProcessParams.splitFxTimeSec
+        );
 
         D3D11_MAPPED_SUBRESOURCE mapped;
         if (SUCCEEDED(m_context->Map(m_cbPostProcess.Get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped)))
@@ -5447,6 +5507,18 @@ namespace Alice
 			postProcessCB.colorGradingContrast = m_postProcessParams.colorGradingContrast;
 			postProcessCB.colorGradingGamma = m_postProcessParams.colorGradingGamma;
 			postProcessCB.colorGradingGain = m_postProcessParams.colorGradingGain;
+			postProcessCB.splitParams = DirectX::XMFLOAT4(
+				m_postProcessParams.splitAmount,
+				m_postProcessParams.splitAngleDeg,
+				m_postProcessParams.splitLineOffset,
+				m_postProcessParams.splitFeather
+			);
+			postProcessCB.splitFxParams = DirectX::XMFLOAT4(
+				m_postProcessParams.splitFxIntensity,
+				m_postProcessParams.splitFxWidth,
+				m_postProcessParams.splitFxSpeed,
+				m_postProcessParams.splitFxTimeSec
+			);
 
 			D3D11_MAPPED_SUBRESOURCE mapped;
 			if (SUCCEEDED(m_context->Map(m_cbPostProcess.Get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped)))

--- a/Engine/src/Runtime/Rendering/ForwardRenderSystem.cpp
+++ b/Engine/src/Runtime/Rendering/ForwardRenderSystem.cpp
@@ -788,7 +788,7 @@ namespace Alice
         if (FAILED(m_device->CreateBuffer(&desc, nullptr, m_cbSkybox.ReleaseAndGetAddressOf()))) return false;
 
         // 4. PostProcess 상수 버퍼 생성 (톤매핑용)
-        desc.ByteWidth = sizeof(float) * 4; // exposure, maxHDRNits, padding[2]
+        desc.ByteWidth = static_cast<UINT>((sizeof(PostProcessCB) + 15) / 16 * 16);
         desc.Usage = D3D11_USAGE_DYNAMIC;
         desc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
         if (FAILED(m_device->CreateBuffer(&desc, nullptr, m_cbPostProcess.ReleaseAndGetAddressOf()))) return false;
@@ -2317,6 +2317,14 @@ namespace Alice
                 m_postProcessParams.colorGradingGain.y,
                 m_postProcessParams.colorGradingGain.z
             );
+            defaultSettings.splitAmount = m_postProcessParams.splitAmount;
+            defaultSettings.splitAngleDeg = m_postProcessParams.splitAngleDeg;
+            defaultSettings.splitLineOffset = m_postProcessParams.splitLineOffset;
+            defaultSettings.splitFeather = m_postProcessParams.splitFeather;
+            defaultSettings.splitFxIntensity = m_postProcessParams.splitFxIntensity;
+            defaultSettings.splitFxWidth = m_postProcessParams.splitFxWidth;
+            defaultSettings.splitFxSpeed = m_postProcessParams.splitFxSpeed;
+            defaultSettings.splitFxTimeSec = m_postProcessParams.splitFxTimeSec;
 
             const std::string referenceName = ResolvePPVReferenceName(world);
             if (referenceName != m_postProcessVolumeSystem.GetReferenceObjectName())
@@ -2357,6 +2365,14 @@ namespace Alice
                 finalSettings.gain.z,
                 1.0f
             );
+            m_postProcessParams.splitAmount = finalSettings.splitAmount;
+            m_postProcessParams.splitAngleDeg = finalSettings.splitAngleDeg;
+            m_postProcessParams.splitLineOffset = finalSettings.splitLineOffset;
+            m_postProcessParams.splitFeather = finalSettings.splitFeather;
+            m_postProcessParams.splitFxIntensity = finalSettings.splitFxIntensity;
+            m_postProcessParams.splitFxWidth = finalSettings.splitFxWidth;
+            m_postProcessParams.splitFxSpeed = finalSettings.splitFxSpeed;
+            m_postProcessParams.splitFxTimeSec = finalSettings.splitFxTimeSec;
         }
 
         // 6. 에디터 뷰포트 표시용 LDR 텍스처로 톤매핑 (ImGui::Image에서 사용)
@@ -2460,6 +2476,14 @@ namespace Alice
                 m_postProcessParams.colorGradingGain.y,
                 m_postProcessParams.colorGradingGain.z
             );
+            defaultSettings.splitAmount = m_postProcessParams.splitAmount;
+            defaultSettings.splitAngleDeg = m_postProcessParams.splitAngleDeg;
+            defaultSettings.splitLineOffset = m_postProcessParams.splitLineOffset;
+            defaultSettings.splitFeather = m_postProcessParams.splitFeather;
+            defaultSettings.splitFxIntensity = m_postProcessParams.splitFxIntensity;
+            defaultSettings.splitFxWidth = m_postProcessParams.splitFxWidth;
+            defaultSettings.splitFxSpeed = m_postProcessParams.splitFxSpeed;
+            defaultSettings.splitFxTimeSec = m_postProcessParams.splitFxTimeSec;
 
             const std::string referenceName = ResolvePPVReferenceName(world);
             if (referenceName != m_postProcessVolumeSystem.GetReferenceObjectName())
@@ -2498,6 +2522,14 @@ namespace Alice
                 finalSettings.gain.z,
                 1.0f
             );
+            m_postProcessParams.splitAmount = finalSettings.splitAmount;
+            m_postProcessParams.splitAngleDeg = finalSettings.splitAngleDeg;
+            m_postProcessParams.splitLineOffset = finalSettings.splitLineOffset;
+            m_postProcessParams.splitFeather = finalSettings.splitFeather;
+            m_postProcessParams.splitFxIntensity = finalSettings.splitFxIntensity;
+            m_postProcessParams.splitFxWidth = finalSettings.splitFxWidth;
+            m_postProcessParams.splitFxSpeed = finalSettings.splitFxSpeed;
+            m_postProcessParams.splitFxTimeSec = finalSettings.splitFxTimeSec;
         }
 
         if (m_viewportRTV)
@@ -2741,6 +2773,18 @@ namespace Alice
         cbData.colorGradingContrast = m_postProcessParams.colorGradingContrast;
         cbData.colorGradingGamma = m_postProcessParams.colorGradingGamma;
         cbData.colorGradingGain = m_postProcessParams.colorGradingGain;
+        cbData.splitParams = DirectX::XMFLOAT4(
+            m_postProcessParams.splitAmount,
+            m_postProcessParams.splitAngleDeg,
+            m_postProcessParams.splitLineOffset,
+            m_postProcessParams.splitFeather
+        );
+        cbData.splitFxParams = DirectX::XMFLOAT4(
+            m_postProcessParams.splitFxIntensity,
+            m_postProcessParams.splitFxWidth,
+            m_postProcessParams.splitFxSpeed,
+            m_postProcessParams.splitFxTimeSec
+        );
 
         D3D11_MAPPED_SUBRESOURCE mapped;
         if (SUCCEEDED(m_context->Map(m_cbPostProcess.Get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped)))

--- a/Engine/src/Runtime/Rendering/PostProcessSettings.h
+++ b/Engine/src/Runtime/Rendering/PostProcessSettings.h
@@ -49,6 +49,39 @@ namespace Alice
         bool bOverride_BloomDownsample = false;
         int bloomDownsample = 2;
 
+        // ==== Screen Split (HalfCut) ====
+        // splitAmount: 분할선 기준 위/아래 절반이 이동하는 UV 오프셋 강도 (0 = 비활성)
+        bool bOverride_SplitAmount = false;
+        float splitAmount = 0.0f;
+
+        // splitAngleDeg: 분할선 각도(도). 0이면 수평 분할, 양수는 반시계 회전.
+        bool bOverride_SplitAngleDeg = false;
+        float splitAngleDeg = 0.0f;
+
+        // splitLineOffset: 분할선 위치 오프셋(정규화 공간). 0이면 화면 중심.
+        bool bOverride_SplitLineOffset = false;
+        float splitLineOffset = 0.0f;
+
+        // splitFeather: 분할 경계부 블렌딩 폭(정규화 공간).
+        bool bOverride_SplitFeather = false;
+        float splitFeather = 0.001f;
+
+        // splitFxIntensity: 절단선 수학 기반 하이라이트 강도 (0 = 비활성)
+        bool bOverride_SplitFxIntensity = false;
+        float splitFxIntensity = 0.0f;
+
+        // splitFxWidth: 절단선 주변 영향 폭(정규화 공간)
+        bool bOverride_SplitFxWidth = false;
+        float splitFxWidth = 0.01f;
+
+        // splitFxSpeed: 절단선 방향 흐름 속도
+        bool bOverride_SplitFxSpeed = false;
+        float splitFxSpeed = 30.0f;
+
+        // splitFxTimeSec: 절단선 이펙트 시간(초)
+        bool bOverride_SplitFxTimeSec = false;
+        float splitFxTimeSec = 0.0f;
+
         /// 기본 설정으로 초기화 (모든 override = false)
         PostProcessSettings() = default;
 
@@ -84,6 +117,14 @@ namespace Alice
             settings.bloomGaussianIntensity = 1.0f;
             settings.bloomRadius = 1.0f;
             settings.bloomDownsample = 2;
+            settings.splitAmount = 0.0f;
+            settings.splitAngleDeg = 0.0f;
+            settings.splitLineOffset = 0.0f;
+            settings.splitFeather = 0.001f;
+            settings.splitFxIntensity = 0.0f;
+            settings.splitFxWidth = 0.01f;
+            settings.splitFxSpeed = 30.0f;
+            settings.splitFxTimeSec = 0.0f;
             return settings;
         }
     };
@@ -143,6 +184,14 @@ namespace Alice
             BlendFloat(final.bloomGaussianIntensity, volume.bloomGaussianIntensity, weight, volume.bOverride_BloomGaussianIntensity);
             BlendFloat(final.bloomRadius, volume.bloomRadius, weight, volume.bOverride_BloomRadius);
             BlendInt(final.bloomDownsample, volume.bloomDownsample, weight, volume.bOverride_BloomDownsample);
+            BlendFloat(final.splitAmount, volume.splitAmount, weight, volume.bOverride_SplitAmount);
+            BlendFloat(final.splitAngleDeg, volume.splitAngleDeg, weight, volume.bOverride_SplitAngleDeg);
+            BlendFloat(final.splitLineOffset, volume.splitLineOffset, weight, volume.bOverride_SplitLineOffset);
+            BlendFloat(final.splitFeather, volume.splitFeather, weight, volume.bOverride_SplitFeather);
+            BlendFloat(final.splitFxIntensity, volume.splitFxIntensity, weight, volume.bOverride_SplitFxIntensity);
+            BlendFloat(final.splitFxWidth, volume.splitFxWidth, weight, volume.bOverride_SplitFxWidth);
+            BlendFloat(final.splitFxSpeed, volume.splitFxSpeed, weight, volume.bOverride_SplitFxSpeed);
+            BlendFloat(final.splitFxTimeSec, volume.splitFxTimeSec, weight, volume.bOverride_SplitFxTimeSec);
         }
 
     }

--- a/Engine/src/Runtime/Rendering/PostProcessVolumeSystem.cpp
+++ b/Engine/src/Runtime/Rendering/PostProcessVolumeSystem.cpp
@@ -521,6 +521,22 @@ namespace Alice
             target.bloomRadius = volumeSettings.bloomRadius;
         if (volumeSettings.bOverride_BloomDownsample)
             target.bloomDownsample = volumeSettings.bloomDownsample;
+        if (volumeSettings.bOverride_SplitAmount)
+            target.splitAmount = volumeSettings.splitAmount;
+        if (volumeSettings.bOverride_SplitAngleDeg)
+            target.splitAngleDeg = volumeSettings.splitAngleDeg;
+        if (volumeSettings.bOverride_SplitLineOffset)
+            target.splitLineOffset = volumeSettings.splitLineOffset;
+        if (volumeSettings.bOverride_SplitFeather)
+            target.splitFeather = volumeSettings.splitFeather;
+        if (volumeSettings.bOverride_SplitFxIntensity)
+            target.splitFxIntensity = volumeSettings.splitFxIntensity;
+        if (volumeSettings.bOverride_SplitFxWidth)
+            target.splitFxWidth = volumeSettings.splitFxWidth;
+        if (volumeSettings.bOverride_SplitFxSpeed)
+            target.splitFxSpeed = volumeSettings.splitFxSpeed;
+        if (volumeSettings.bOverride_SplitFxTimeSec)
+            target.splitFxTimeSec = volumeSettings.splitFxTimeSec;
 
         return target;
     }

--- a/Engine/src/Runtime/Rendering/RenderTypes.h
+++ b/Engine/src/Runtime/Rendering/RenderTypes.h
@@ -73,6 +73,26 @@ namespace Alice
             1.0f 
         };  // Gain: Multiply 스케일 (R,G,B 채널별, 0.0 = 검정, 1.0 = 원본, >1.0 = 밝게, W=1.0)
             // 주의: 이것은 "출력 감마 보정"이 아니라 Color Grading 단계에서 색상을 곱하는 룩 조절 파라미터입니다.
+
+        // HalfCut 화면 분할 연출 파라미터
+        // splitAmount: 분할선 기준 절반 화면 UV 이동량 (0 = 비활성)
+        // splitAngleDeg: 분할선 각도(도, 0 = 수평 분할)
+        // splitLineOffset: 분할선 위치 오프셋(정규화 공간)
+        // splitFeather: 경계부 블렌딩 폭(정규화 공간)
+        float splitAmount = 0.0f;
+        float splitAngleDeg = 0.0f;
+        float splitLineOffset = 0.0f;
+        float splitFeather = 0.001f;
+
+        // Split 절단선 하이라이트/스파크(수학 기반) 파라미터
+        // splitFxIntensity: 0이면 비활성
+        // splitFxWidth: 절단선 주변 영향 폭(정규화 공간)
+        // splitFxSpeed: 절단선 방향 흐름 속도
+        // splitFxTimeSec: 연출 시간(초), 스크립트에서 제어
+        float splitFxIntensity = 0.0f;
+        float splitFxWidth = 0.01f;
+        float splitFxSpeed = 30.0f;
+        float splitFxTimeSec = 0.0f;
     };
 
     /// Bloom 파라미터 구조체
@@ -226,6 +246,8 @@ namespace Alice
 		DirectX::XMFLOAT4 colorGradingContrast;    // Color Grading Contrast: 룩 조절 (R,G,B 채널별, Pivot=0.5 기반, W=1.0)
 		DirectX::XMFLOAT4 colorGradingGamma;       // Color Grading Gamma: 룩/중간톤 조절 (R,G,B 채널별, W=1.0)
 		DirectX::XMFLOAT4 colorGradingGain;       // Color Grading Gain: Multiply 스케일 (R,G,B 채널별, W=1.0)
+        DirectX::XMFLOAT4 splitParams;            // x: splitAmount, y: splitAngleDeg, z: splitLineOffset, w: splitFeather
+        DirectX::XMFLOAT4 splitFxParams;          // x: splitFxIntensity, y: splitFxWidth, z: splitFxSpeed, w: splitFxTimeSec
 	};
 
 	struct BloomCB

--- a/Engine/src/Runtime/Rendering/ShaderCode/CommonShaderCode.h
+++ b/Engine/src/Runtime/Rendering/ShaderCode/CommonShaderCode.h
@@ -92,6 +92,8 @@ cbuffer PostProcessConstantBuffer : register(b2)
                                       // 주의: 이것은 "출력 감마 보정"이 아니라 luminance에 영향을 주는 color grading 파라미터입니다.
     float4 g_ColorGradingGain;      // Color Grading Gain: Multiply 스케일 (R,G,B 채널별, 0.0 = 검정, 1.0 = 원본, >1.0 = 밝게, W=1.0)
                                       // 주의: 이것은 "출력 감마 보정"이 아니라 Color Grading 단계에서 색상을 곱하는 룩 조절 파라미터입니다.
+    float4 g_SplitParams;            // x: splitAmount, y: splitAngleDeg, z: splitLineOffset, w: splitFeather
+    float4 g_SplitFxParams;          // x: splitFxIntensity, y: splitFxWidth, z: splitFxSpeed, w: splitFxTimeSec
 };
 
 struct PS_INPUT_QUAD
@@ -158,9 +160,80 @@ float3 ApplyColorGradingGamma(float3 color, float3 gammaColor)
       return color * gainColor;
   }
 
+float2 ApplyHalfCutUV(float2 uv)
+{
+    float amount = g_SplitParams.x;
+    if (abs(amount) < 1e-6f)
+        return uv;
+
+    float angle = radians(g_SplitParams.y);
+    float lineOffset = g_SplitParams.z;
+    float feather = max(abs(g_SplitParams.w), 1e-6f);
+
+    float2 lineDir = float2(cos(angle), sin(angle));
+    float2 normal = float2(-lineDir.y, lineDir.x);
+    float2 centered = uv - float2(0.5f, 0.5f);
+    float side = dot(centered, normal) - lineOffset;
+
+    // side < 0 (하단): +lineDir, side > 0 (상단): -lineDir
+    float sideBlend = smoothstep(-feather, feather, side);
+    float directionSign = lerp(1.0f, -1.0f, sideBlend);
+    return uv + lineDir * (amount * directionSign);
+}
+
+float Hash11(float p)
+{
+    p = frac(p * 0.1031f);
+    p *= p + 33.33f;
+    p *= p + p;
+    return frac(p);
+}
+
+float3 ApplySplitCutFx(float3 color, float2 uv)
+{
+    float intensity = max(g_SplitFxParams.x, 0.0f);
+    if (intensity <= 1e-6f)
+        return color;
+
+    float width = max(g_SplitFxParams.y, 1e-5f);
+    float speed = g_SplitFxParams.z;
+    float timeSec = g_SplitFxParams.w;
+
+    float angle = radians(g_SplitParams.y);
+    float lineOffset = g_SplitParams.z;
+
+    float2 lineDir = float2(cos(angle), sin(angle));
+    float2 normal = float2(-lineDir.y, lineDir.x);
+    float2 centered = uv - float2(0.5f, 0.5f);
+
+    float side = dot(centered, normal) - lineOffset;
+    float along = dot(centered, lineDir);
+
+    float edgeBand = exp(-abs(side) / width);
+    float core = exp(-abs(side) / max(width * 0.35f, 1e-5f));
+
+    float sweep = along * 180.0f + timeSec * speed;
+    float n0 = Hash11(sweep + 0.13f);
+    float n1 = Hash11(sweep * 1.73f - 2.41f);
+    float sparks = saturate((n0 * 0.65f + n1 * 0.35f) * 1.9f - 1.0f);
+    sparks *= sparks;
+
+    float3 glowColor = float3(2.8f, 1.2f, 0.45f);
+    float3 fringeColor = float3(0.10f, 1.05f, 0.95f);
+
+    float glow = edgeBand * (0.35f + sparks * 1.25f);
+    float dark = core * 0.55f;
+
+    float3 result = color * (1.0f - dark * saturate(intensity * 0.8f));
+    result += (glowColor * glow + fringeColor * sparks * edgeBand) * intensity;
+    return result;
+}
+
 float4 main(PS_INPUT_QUAD input) : SV_Target
 {
-    float3 C_linear709 = g_SceneHDR.Sample(g_SamplerLinear, input.uv).rgb;
+    float2 splitUV = ApplyHalfCutUV(input.uv);
+    float3 C_linear709 = g_SceneHDR.Sample(g_SamplerLinear, splitUV).rgb;
+    C_linear709 = ApplySplitCutFx(C_linear709, input.uv);
     
     // 1. Exposure 적용
     float exposureFactor = pow(2.0f, g_Exposure);
@@ -203,6 +276,8 @@ cbuffer PostProcessConstantBuffer : register(b2)
                                       // 주의: 이것은 "출력 감마 보정"이 아니라 luminance에 영향을 주는 color grading 파라미터입니다.
     float4 g_ColorGradingGain;      // Color Grading Gain: Multiply 스케일 (R,G,B 채널별, 0.0 = 검정, 1.0 = 원본, >1.0 = 밝게, W=1.0)
                                       // 주의: 이것은 "출력 감마 보정"이 아니라 Color Grading 단계에서 색상을 곱하는 룩 조절 파라미터입니다.
+    float4 g_SplitParams;            // x: splitAmount, y: splitAngleDeg, z: splitLineOffset, w: splitFeather
+    float4 g_SplitFxParams;          // x: splitFxIntensity, y: splitFxWidth, z: splitFxSpeed, w: splitFxTimeSec
 };
 
 struct PS_INPUT_QUAD
@@ -266,6 +341,75 @@ float3 ApplyColorGradingGain(float3 color, float3 gainColor)
     return color * gainColor;
 }
 
+float2 ApplyHalfCutUV(float2 uv)
+{
+    float amount = g_SplitParams.x;
+    if (abs(amount) < 1e-6f)
+        return uv;
+
+    float angle = radians(g_SplitParams.y);
+    float lineOffset = g_SplitParams.z;
+    float feather = max(abs(g_SplitParams.w), 1e-6f);
+
+    float2 lineDir = float2(cos(angle), sin(angle));
+    float2 normal = float2(-lineDir.y, lineDir.x);
+    float2 centered = uv - float2(0.5f, 0.5f);
+    float side = dot(centered, normal) - lineOffset;
+
+    // side < 0 (하단): +lineDir, side > 0 (상단): -lineDir
+    float sideBlend = smoothstep(-feather, feather, side);
+    float directionSign = lerp(1.0f, -1.0f, sideBlend);
+    return uv + lineDir * (amount * directionSign);
+}
+
+float Hash11(float p)
+{
+    p = frac(p * 0.1031f);
+    p *= p + 33.33f;
+    p *= p + p;
+    return frac(p);
+}
+
+float3 ApplySplitCutFx(float3 color, float2 uv)
+{
+    float intensity = max(g_SplitFxParams.x, 0.0f);
+    if (intensity <= 1e-6f)
+        return color;
+
+    float width = max(g_SplitFxParams.y, 1e-5f);
+    float speed = g_SplitFxParams.z;
+    float timeSec = g_SplitFxParams.w;
+
+    float angle = radians(g_SplitParams.y);
+    float lineOffset = g_SplitParams.z;
+
+    float2 lineDir = float2(cos(angle), sin(angle));
+    float2 normal = float2(-lineDir.y, lineDir.x);
+    float2 centered = uv - float2(0.5f, 0.5f);
+
+    float side = dot(centered, normal) - lineOffset;
+    float along = dot(centered, lineDir);
+
+    float edgeBand = exp(-abs(side) / width);
+    float core = exp(-abs(side) / max(width * 0.35f, 1e-5f));
+
+    float sweep = along * 180.0f + timeSec * speed;
+    float n0 = Hash11(sweep + 0.13f);
+    float n1 = Hash11(sweep * 1.73f - 2.41f);
+    float sparks = saturate((n0 * 0.65f + n1 * 0.35f) * 1.9f - 1.0f);
+    sparks *= sparks;
+
+    float3 glowColor = float3(2.8f, 1.2f, 0.45f);
+    float3 fringeColor = float3(0.10f, 1.05f, 0.95f);
+
+    float glow = edgeBand * (0.35f + sparks * 1.25f);
+    float dark = core * 0.55f;
+
+    float3 result = color * (1.0f - dark * saturate(intensity * 0.8f));
+    result += (glowColor * glow + fringeColor * sparks * edgeBand) * intensity;
+    return result;
+}
+
 // Rec709 to Rec2020 색공간 변환
 float3 Rec709ToRec2020(float3 color)
 {
@@ -298,7 +442,9 @@ float3 LinearToST2084(float3 color)
 float4 main(PS_INPUT_QUAD input) : SV_Target
 {
     // 예제 프로젝트 36_ToneMappingPS_HDR.hlsl와 동일한 로직
-    float3 C_linear709 = g_SceneHDR.Sample(g_SamplerLinear, input.uv).rgb;
+    float2 splitUV = ApplyHalfCutUV(input.uv);
+    float3 C_linear709 = g_SceneHDR.Sample(g_SamplerLinear, splitUV).rgb;
+    C_linear709 = ApplySplitCutFx(C_linear709, input.uv);
     
     // 1. Exposure 적용
     float3 C_exposure = C_linear709 * pow(2.0f, g_Exposure);


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #

## 📝 작업 내용
- [x] 카메라 잘림 연출
- [x] 카메라 잘림 연출을 위한 포스트 프로세스 볼륨에 기능 추가
- [x] 카메라의 이동을 더 부드럽게 하기 위해 FOV에 애님 커브 애셋 적용

Scene/Camera/CameraHalfCut.scene 을 열어보세요

PostProcessVolume → Blend → RenderSystem → ContantBuffer → Shader 이렇게 실행됨

## 🔬 테스트 방법 (없으면 삭제)
- 

## 📸 스크린샷 (선택)

<img width="1534" height="906" alt="image" src="https://github.com/user-attachments/assets/a016c45b-e4f3-46bd-9975-464c35b08798" />


<img width="1549" height="907" alt="image" src="https://github.com/user-attachments/assets/19631d09-2023-4e0c-89c9-2f53f45b2701" />


<img width="1545" height="889" alt="image" src="https://github.com/user-attachments/assets/bb4759e2-cc2f-4af8-968a-29f27d76f549" />


## ✅ 체크리스트
- [x] 빌드가 에러 없이 정상적으로 되나요?
- [ ] 불필요한 로그나 주석을 제거했나요?
- [x] 코딩 컨벤션을 지켰나요?